### PR TITLE
Fix Example for macOS Support

### DIFF
--- a/example/triangle.slang
+++ b/example/triangle.slang
@@ -15,7 +15,7 @@ static const Vertex VERTICES[3] = {
 };
 
 [shader("vertex")]
-V2P vertex(uint vertex_index: SV_VertexID) {
+V2P vertexmain(uint vertex_index: SV_VertexID) {
     let vertex = VERTICES[vertex_index];
     
     V2P output;
@@ -31,7 +31,7 @@ struct PSOutput {
 };
 
 [shader("fragment")]
-PSOutput fragment(V2P input) {
+PSOutput fragmentmain(V2P input) {
     PSOutput output;
     output.frag_color = float4(input.color, 1.0);
     return output;


### PR DESCRIPTION
Previously, the example did not run on macOS (under ARM). I managed to get it working under the latest macOS Sequoia 15.2 on a M4 Pro chip.

These are the changes implemented:
- Use portability enumeration extension on the instance to load not-fully-conforming versions of Vulkan.
- If the portability enumeration extension is used, *also* use the portability subset device extension. (Required by Vulkan specification.)
- Since Vulkan 1.3 is not fully supported by the latest MoltenVK, so some extensions that were used implicitly are now used explicitly (and referenced by the KHR suffix). This is required on macOS as otherwise the function pointers will be nil, crashing the program. The reverse though (using KHR variants on 1.3) will not crash according to the Vulkan spec. (The KHR variants will be declared as aliases.)
- MoltenVK used the direct entry point names (`vertex` and `fragment`) in the internally generated MSL, which is a syntax error. To get the code working, I renamed the entry point functions to `vertexmain` and `fragmentmain`.
- The example's slang check function did `:=-` when assigning the result, which takes away the error bit (`0x80000000`) causing all errors to be ignored as passes. Meanwhile, most passes are encoded as `0` which has no effect on negation, so the error wasn't obvious since the example worked on Windows. So I removed the `-`.
- I added calls to the slang check function around where the vertex and fragment shader entry points are searched for. The nil check worked, but I wanted to see more information about why it failed.

I confirmed that typical application lifecycle works as expected (startup, rendering, shutdown), and that hot reloading of the shader works.

I was not able to confirm that the Windows example works the same though, as I do not have access to a regular x64 PC to test on at the moment, and won't for a few weeks.