### PR TITLE
Reflection & other additions

### DIFF
--- a/example/reflection_api/compute-simple.slang
+++ b/example/reflection_api/compute-simple.slang
@@ -1,0 +1,24 @@
+// compute-simple.slang
+
+static const uint THREADGROUP_SIZE_X = 8;
+static const uint THREADGROUP_SIZE_Y = THREADGROUP_SIZE_X;
+
+struct ImageProcessingOptions
+{
+    float3 tintColor;
+    float blurRadius;
+
+    bool useLookupTable;
+    StructuredBuffer<float4> lookupTable;
+}
+
+[shader("compute")]
+[numthreads(THREADGROUP_SIZE_X, THREADGROUP_SIZE_Y)]
+void processImage(
+    uint3 threadID : SV_DispatchThreadID,
+    uniform Texture2D inputImage,
+    uniform RWTexture2D outputImage,
+    uniform ImageProcessingOptions options)
+{
+    /* actual logic would go here */
+}

--- a/example/reflection_api/example.odin
+++ b/example/reflection_api/example.odin
@@ -1,0 +1,824 @@
+package reflection_example
+
+import "core:fmt"
+
+import sp "../../slang"
+
+import ex ".."
+
+// ported from https://github.com/shader-slang/slang/tree/master/examples/reflection-api
+
+main :: proc() {
+	global_session: ^sp.IGlobalSession
+	ensure(sp.createGlobalSession(sp.API_VERSION, &global_session) == sp.OK)
+	defer sp.shutdown()
+
+	target_desc := sp.TargetDesc {
+		structureSize = size_of(sp.TargetDesc),
+		format        = .SPIRV,
+		flags         = {.GENERATE_SPIRV_DIRECTLY},
+		profile       = global_session->findProfile("sm_6_0"),
+	}
+
+	session_desc := sp.SessionDesc {
+		structureSize            = size_of(sp.SessionDesc),
+		targets                  = &target_desc,
+		targetCount              = 1,
+	}
+
+	session: ^sp.ISession
+	global_session->createSession(session_desc, &session)
+	defer session->release() 
+
+	g_SourceFileNames = {
+		"compute-simple.slang",
+		"raster-simple.slang",
+	}
+
+	res := compileAndReflectPrograms(session)
+	ex.slang_check(res)
+	fmt.println("")
+}
+
+g_afterArrayElement: bool = true
+g_indentation: int
+g_metadataForEntryPoints: [dynamic]^sp.IMetadata
+g_programLayout: ^sp.ProgramLayout
+g_SourceFileNames: []cstring
+
+printIndentation :: proc() {
+	for _ in 1..<g_indentation {
+		print(" ")
+	}
+}
+
+common_print :: proc(args: ..any) {
+	fmt.print(..args)
+}
+
+printf             :: fmt.printf
+printResourceShape :: proc(shape: sp.SlangResourceShape) {
+	SCOPED_OBJECT()
+	key("base")
+	common_print(shape & .BASE_SHAPE_MASK)
+}
+printComment :: proc(args: ..any) {
+	printf("# %s",..args)
+}
+
+print                 :: common_print
+printBool             :: common_print
+printTypeKind         :: common_print
+printScalarType       :: common_print
+printResourceAccess   :: common_print
+printLayoutUnit       :: common_print
+printMatrixLayoutMode :: common_print
+printStage            :: common_print
+printTargetFormat     :: common_print
+
+StageMask :: bit_set[sp.Stage; u32]
+
+INDENT :: 4
+beginObject :: proc() { g_indentation += INDENT }
+endObject   :: proc() { g_indentation -= INDENT }
+beginArray  :: proc() { g_indentation += INDENT }
+endArray    :: proc() { g_indentation -= INDENT }
+
+@(deferred_none=endObject)
+SCOPED_OBJECT :: proc() {
+	beginObject()
+}
+
+@(deferred_none=endArray)
+WITH_ARRAY :: proc() {
+	beginArray()
+}
+
+newLine :: proc() {
+	print("\n")
+	printIndentation()
+}
+
+key :: proc(key: cstring) {
+	if !g_afterArrayElement {
+		newLine()
+	}
+	g_afterArrayElement = false
+
+	printf("%s: ", key)
+}
+
+element :: proc() {
+	newLine()
+	printf("- ")
+	g_afterArrayElement = true
+}
+
+printQuotedString :: proc(text: cstring) {
+	if text != "" {
+		printf("\"%s\"", text)
+	} else {
+		print("null")
+	}
+}
+
+printVariable :: proc(variable: ^sp.VariableReflection) {
+	SCOPED_OBJECT()
+
+	name := sp.variable_getName(variable)
+	type := sp.variable_getType(variable)
+
+	key("name")
+	printQuotedString(name)
+	key("type")
+	printType(type)
+
+	value: i64
+	if sp.SUCCEEDED(sp.variable_getDefaultValueInt(variable, &value)){
+		key("value")
+		print(value)
+	}
+}
+
+
+
+printCommonTypeInfo :: proc(type: ^sp.TypeReflection) {
+	#partial switch sp.type_getKind(type) {
+	case .Scalar: 
+		key("scalar type")
+		printScalarType(sp.type_getScalarType(type))
+	case .Array:
+		key("element count")
+		printPossiblyUnbounded(sp.type_getElementCount(type))
+	case .Vector:
+		key("element count")
+		print(sp.type_getElementCount(type))
+	case .Matrix:
+		key("row count")
+		print(sp.type_getRowCount(type))
+		key("column count")
+		print(sp.type_getColumnCount(type))
+	case .Resource:
+		key("shape")
+		printResourceShape(sp.type_getResourceShape(type))
+		key("access")
+		printResourceAccess(sp.type_getResourceAccess(type))
+	case:
+	}
+}
+
+
+
+printType :: proc(type: ^sp.TypeReflection) {
+	SCOPED_OBJECT()
+	name := sp.type_getName(type)
+	kind := sp.type_getKind(type)
+
+	key("name")
+	printQuotedString(name)
+	key("kind")
+	printTypeKind(kind)
+
+	printCommonTypeInfo(type)
+
+	#partial switch sp.type_getKind(type) {
+	case .Struct:
+		key("fields")
+		fieldCount := sp.type_getFieldCount(type)
+		
+		WITH_ARRAY(); for f in 0..<fieldCount {
+			element()
+			field := sp.type_getFieldByIndex(type, f)
+			printVariable(field)
+		}
+	case .Array, .Vector, .Matrix:
+		key("element type")
+		printType(sp.type_getElementType(type))
+	case .Resource:
+		key("result type")
+		printType(sp.type_getResourceResultType(type))
+	case .ConstantBuffer, .ParameterBlock, .TextureBuffer, .ShaderStorageBuffer:
+	// "single-element containers" 
+	// https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/09-reflection.html#pitfalls-to-avoid    
+		key("element type")
+		printType(sp.type_getElementType(type))
+	case:
+	}	
+}
+
+printPossiblyUnbounded :: proc(value: uint) {
+	if value == sp.UNBOUNDED_SIZE {
+		printf("unbounded")
+	} else {
+		printf("%d", value)
+	}
+}
+
+printVariableLayout :: proc(variableLayout: ^sp.VariableLayoutReflection, accessPath: AccessPath) {
+	SCOPED_OBJECT()
+
+	key("name")
+	printQuotedString(sp.variable_layout_getName(variableLayout))
+
+	printOffsets(variableLayout, accessPath)
+
+	printVaryingParameterInfo(variableLayout)
+
+	variablePath: ExtendedAccessPath
+	initExtendedAccessPath(&variablePath, accessPath, variableLayout)
+
+	key("type layout")
+	printTypeLayout(sp.variable_layout_getTypeLayout(variableLayout), variablePath)
+}
+
+initExtendedAccessPath :: proc(
+	eap:            ^ExtendedAccessPath,
+	accessPath:     AccessPath,
+	variableLayout: ^sp.VariableLayoutReflection
+) {
+	if !accessPath.valid {
+		return 
+	}
+
+	eap.accessPath = accessPath
+	eap.element.variableLayout = variableLayout
+	eap.element.outer = accessPath.leaf
+	eap.leaf = &eap.element
+}
+
+AccessPath :: struct {
+	valid: bool,
+	deepestConstantBufer : ^AccessPathNode,
+	deepestParameterBlock: ^AccessPathNode,
+	leaf: ^AccessPathNode,
+}
+
+ExtendedAccessPath :: struct {
+	using accessPath: AccessPath,
+	element:          AccessPathNode,
+}
+
+AccessPathNode :: struct {
+	variableLayout: ^sp.VariableLayoutReflection,
+	outer:          ^AccessPathNode,
+}
+
+printVaryingParameterInfo :: proc(variableLayout: ^sp.VariableLayoutReflection) {
+	semanticName := sp.variable_layout_getSemanticName(variableLayout)
+	if semanticName != "" {
+		key("semantic")
+		SCOPED_OBJECT()
+		key("name")
+		printQuotedString(semanticName)
+		key("index")
+		print(sp.variable_layout_getSemanticIndex(variableLayout))
+	}
+}
+
+printCumulativeOffsets :: proc(
+	variableLayout: ^sp.VariableLayoutReflection,
+	accessPath: AccessPath,
+) {
+	key("cumulative")
+
+	usedLayoutUnitCount := sp.variable_layout_getCategoryCount(variableLayout)
+	WITH_ARRAY(); for i in 0..<usedLayoutUnitCount {
+		element()
+		layoutUnit := sp.variable_layout_getCategoryByIndex(variableLayout, i)
+		printCumulativeOffset(variableLayout, layoutUnit, accessPath)
+	}
+}	
+
+printCumulativeOffset :: proc(
+	variableLayout: ^sp.VariableLayoutReflection,
+	layoutUnit:     sp.LayoutUnit,
+	accessPath:     AccessPath
+) {
+	cumulativeOffset := calculateCumulativeOffset(variableLayout, layoutUnit, accessPath)
+	printOffset(layoutUnit, cumulativeOffset.value, cumulativeOffset.space)
+}
+
+CumulativeOffset :: struct {
+	value: uint,
+	space: uint,
+}
+
+calculateCumulativeOffset2 :: proc(
+	layoutUnit: sp.LayoutUnit,
+	accessPath: AccessPath,
+) -> CumulativeOffset {
+	result: CumulativeOffset
+	#partial switch layoutUnit {
+	// #### Layout Units That Don't Require Special Handling
+	//
+	case:
+		for node := accessPath.leaf; node != nil; node = node.outer {
+			result.value += sp.variable_layout_getOffset(node.variableLayout, layoutUnit)
+		}
+	// #### Bytes
+	//
+	case .Uniform:
+		for node := accessPath.leaf; node != accessPath.deepestConstantBufer; node = node.outer {
+			result.value += sp.variable_layout_getOffset(node.variableLayout, layoutUnit)
+		}
+	// #### Layout Units That Care About Spaces
+	//
+	case .ConstantBuffer, .ShaderResource, .UnorderedAccess, .SamplerState, .DescriptorTableSlot:
+		for node := accessPath.leaf; node != accessPath.deepestParameterBlock; node = node.outer {
+			result.value += sp.variable_layout_getOffset(node.variableLayout, layoutUnit)
+			result.space += sp.variable_layout_getBindingSpace(node.variableLayout, layoutUnit)
+		}
+		for node := accessPath.deepestParameterBlock; node != nil; node = node.outer {
+			result.space += sp.variable_layout_getOffset(node.variableLayout, .SubElementRegisterSpace)
+		}
+	}
+	return result
+}
+
+calculateCumulativeOffset :: proc(
+	variableLayout: ^sp.VariableLayoutReflection,
+	layoutUnit:     sp.LayoutUnit,
+	accessPath:     AccessPath,
+) -> CumulativeOffset {
+	result := calculateCumulativeOffset2(layoutUnit, accessPath)
+	result.value += sp.variable_layout_getOffset(variableLayout, layoutUnit)
+	result.space += sp.variable_layout_getBindingSpace(variableLayout, layoutUnit)
+	return result
+}
+
+printOffsets :: proc(variableLayout: ^sp.VariableLayoutReflection, accessPath: AccessPath) {
+	key("offset")
+	{
+		SCOPED_OBJECT()
+		printRelativeOffsets(variableLayout)
+
+		if accessPath.valid {
+			printCumulativeOffsets(variableLayout, accessPath)
+		}
+	}
+
+
+	if accessPath.valid {
+		printStageUsage(variableLayout, accessPath)
+	}
+}
+
+calculateStageMask :: proc(
+	variableLayout: ^sp.VariableLayoutReflection,
+	accessPath: AccessPath,
+) -> StageMask {
+	mask: StageMask
+
+	usedLayoutUnitCount := sp.variable_layout_getCategoryCount(variableLayout)
+	for i in 0..<usedLayoutUnitCount {
+		layoutUnit := sp.variable_layout_getCategoryByIndex(variableLayout, i)
+		offset := calculateCumulativeOffset(variableLayout, layoutUnit, accessPath)
+
+		mask |= calculateParameterStageMask(layoutUnit, offset)
+	}
+
+	return mask
+}
+
+ calculateParameterStageMask :: proc(
+	layoutUnit: sp.LayoutUnit ,
+	offset: CumulativeOffset ,
+) -> StageMask {
+	mask := StageMask{}
+	entryPointCount := len(g_metadataForEntryPoints)
+	for i in 0..<entryPointCount {
+		isUsed := false
+		g_metadataForEntryPoints[i]->isParameterLocationUsed(
+			sp.SlangParameterCategory(layoutUnit),
+			offset.space,
+			offset.value,
+			&isUsed
+		)
+		if isUsed {
+			entryPointStage := sp.entry_point_getStage(sp.program_layout_getEntryPointByIndex(g_programLayout, uint(i)))
+			mask += {entryPointStage}
+		}
+	}
+	return mask
+}
+
+printStageUsage :: proc(variableLayout: ^sp.VariableLayoutReflection, accessPath: AccessPath) {
+	stageMask := calculateStageMask(variableLayout, accessPath)
+
+	key("used by stages")
+	WITH_ARRAY(); for stage in stageMask {
+		if stage in stageMask {
+			element()
+			printStage(stage)
+		}
+	}
+
+	g_afterArrayElement = false
+}
+
+printOffset :: proc {
+	printOffset1,
+	printOffset2,
+}
+
+printOffset1 :: proc(
+	variableLayout: ^sp.VariableLayoutReflection,
+	layoutUnit: sp.LayoutUnit
+) {
+	printOffset(
+		layoutUnit,
+		sp.variable_layout_getOffset(variableLayout, layoutUnit),
+		sp.variable_layout_getBindingSpace(variableLayout, layoutUnit)
+	)
+}
+
+printOffset2 :: proc(layoutUnit: sp.LayoutUnit, offset, spaceOffset: uint) {
+	SCOPED_OBJECT()
+	key("value")
+	print(offset)
+	key("unit")
+	printLayoutUnit(layoutUnit)
+
+	// #### Spaces / Sets
+	#partial switch layoutUnit {
+	case .ConstantBuffer, .ShaderResource, .UnorderedAccess, .SamplerState, .DescriptorTableSlot:
+		key("space")
+		print(spaceOffset)
+	case:
+	}
+}
+
+printRelativeOffsets :: proc(variableLayout: ^sp.VariableLayoutReflection) {
+	key("relative")
+	usedLayoutUnitCount := sp.variable_layout_getCategoryCount(variableLayout)
+	
+	WITH_ARRAY(); for i in 0..<usedLayoutUnitCount {
+		element()
+
+		layoutUnit := sp.variable_layout_getCategoryByIndex(variableLayout, i)
+		printOffset(variableLayout, layoutUnit)
+	}
+}
+
+printKindSpecificInfo :: proc(typeLayout: ^sp.TypeLayoutReflection, accessPath: AccessPath) {
+	#partial switch sp.type_layout_getKind(typeLayout) {
+	case .Struct:
+		key("fields")
+		fieldCount := sp.type_layout_getFieldCount(typeLayout)
+		WITH_ARRAY(); for f in 0..<fieldCount {
+			element()
+			field := sp.type_layout_getFieldByIndex(typeLayout, f)
+			printVariableLayout(field, accessPath)
+		}
+	case .Array, .Vector:
+		key("element type layout")
+		printTypeLayout(sp.type_layout_getElementTypeLayout(typeLayout), {})
+	case .Matrix:
+		// Note that the concepts of “row” and “column” as employed by Slang are the opposite of how Vulkan,
+		// SPIR-V, GLSL, and OpenGL use those terms. When Slang reflects a matrix as using row-major layout,
+		// the corresponding matrix in generated SPIR-V will have a ColMajor decoration.
+		// For an explanation of why these conventions differ, please see the relevant appendix.
+		// https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/a1-01-matrix-layout.html
+		key("matrix layout mode")
+		printMatrixLayoutMode(sp.type_layout_getMatrixLayoutMode(typeLayout))
+
+		key("element type layout")
+		printTypeLayout(sp.type_layout_getElementTypeLayout(typeLayout), {})
+	case .ConstantBuffer, .ParameterBlock, .TextureBuffer, .ShaderStorageBuffer:
+		containerVarLayout := sp.type_layout_getContainerVarLayout(typeLayout)
+		elementVarLayout := sp.type_layout_getElementVarLayout(typeLayout)
+
+		innerOffsets := accessPath
+		innerOffsets.deepestConstantBufer = innerOffsets.leaf
+		if sp.type_layout_getSize(sp.variable_layout_getTypeLayout(containerVarLayout), .SubElementRegisterSpace) != 0 {
+			innerOffsets.deepestParameterBlock = innerOffsets.leaf
+		}
+
+		key("container")
+		{
+			SCOPED_OBJECT()
+			printOffsets(containerVarLayout, innerOffsets)
+		}
+
+		key("content")
+		{
+			SCOPED_OBJECT()
+			printOffsets(elementVarLayout, innerOffsets)
+
+			elementOffsets: ExtendedAccessPath
+			initExtendedAccessPath(&elementOffsets, innerOffsets, elementVarLayout)
+
+			key("type layout")
+			printTypeLayout(sp.variable_layout_getTypeLayout(elementVarLayout), elementOffsets)
+		}
+	case .Resource:
+		resource_shape := sp.type_layout_getResourceShape(typeLayout)
+		if u32(resource_shape & .BASE_SHAPE_MASK) ==
+			u32(sp.SlangResourceShape(.STRUCTURED_BUFFER)) {
+			key("element type layout")
+			printTypeLayout(sp.type_layout_getElementTypeLayout(typeLayout), accessPath)
+		} else {
+			key("result type")
+			printType(sp.type_layout_getResourceResultType(typeLayout))
+		}	
+	case: 
+	}
+}
+
+printTypeLayout :: proc(typeLayout: ^sp.TypeLayoutReflection, accessPath: AccessPath) {
+	SCOPED_OBJECT()
+
+	key("name")
+	printQuotedString(sp.type_layout_getName(typeLayout))
+	key("kind")
+	printTypeKind(sp.type_layout_getKind(typeLayout))
+	printCommonTypeInfo(sp.type_layout_getType(typeLayout))
+
+	printSizes(typeLayout)
+
+	printKindSpecificInfo(typeLayout, accessPath)
+
+}
+
+printSize :: proc {
+	printSize1,
+	printSize2,
+}
+
+printSize1 :: proc(typeLayout: ^sp.TypeLayoutReflection, layoutUnit: sp.LayoutUnit) {
+	printSize(layoutUnit, sp.type_layout_getSize(typeLayout, layoutUnit))
+}
+
+printSize2 :: proc(layoutUnit: sp.LayoutUnit, size: uint) {
+	SCOPED_OBJECT()
+
+	key("value")
+	printPossiblyUnbounded(size)
+	key("unit")
+	printLayoutUnit(layoutUnit)
+}
+
+printSizes :: proc(typeLayout: ^sp.TypeLayoutReflection) {
+	key("size")
+	usedLayoutUnitCount := sp.type_layout_getCategoryCount(typeLayout)
+	
+	WITH_ARRAY(); for i in 0..<usedLayoutUnitCount {
+		element()
+
+		layoutUnit := sp.type_layout_getCategoryByIndex(typeLayout, i)
+		printSize(typeLayout, layoutUnit)
+	}
+}
+
+// ### Global Scope
+//
+printScope :: proc(scopeVarLayout: ^sp.VariableLayoutReflection, accessPath: AccessPath) {
+	scopeOffsets: ExtendedAccessPath
+	initExtendedAccessPath(&scopeOffsets, accessPath, scopeVarLayout)
+
+	scopeTypeLayout := sp.variable_layout_getTypeLayout(scopeVarLayout)
+	#partial switch sp.type_layout_getKind(scopeTypeLayout) {
+	// #### Parameters are Grouped Into a Structure
+	//
+	case .Struct:
+		key("parameters")
+
+		paramCount := sp.type_layout_getFieldCount(scopeTypeLayout)
+		for i in 0..<paramCount {
+			element()
+			param := sp.type_layout_getFieldByIndex(scopeTypeLayout, i)
+			printVariableLayout(param, scopeOffsets)
+		}
+	
+
+	// #### Wrapped in a Constant Buffer If Needed
+	//
+	case .ConstantBuffer:
+		key("automatically-introduced constant buffer")
+		{
+			SCOPED_OBJECT()
+			printOffsets(sp.type_layout_getContainerVarLayout(scopeTypeLayout), scopeOffsets)
+		}
+
+		printScope(sp.type_layout_getElementVarLayout(scopeTypeLayout), scopeOffsets)
+
+	// #### Wrapped in a Parameter Block If Needed
+	//
+	case .ParameterBlock:
+		key("automatically-introduced parameter block")
+		{
+			SCOPED_OBJECT()
+			printOffsets(sp.type_layout_getContainerVarLayout(scopeTypeLayout), scopeOffsets)
+		}
+
+		printScope(sp.type_layout_getElementVarLayout(scopeTypeLayout), scopeOffsets)
+
+	case:
+	// Note that this default case is never expected to
+	// arise with the current Slang compiler and reflection
+	// API, but we include it here as a kind of failsafe.
+	//
+		key("variable layout")
+		printVariableLayout(scopeVarLayout, accessPath)
+	}
+
+}
+
+printProgramLayout :: proc(programLayout: ^sp.ProgramLayout, targetFormat: sp.CompileTarget) {
+	{
+		SCOPED_OBJECT()
+
+		// g_metadataForEntryPoints: [dynamic]^sp.IMetadata
+		g_programLayout = programLayout
+
+		key("target")
+		printTargetFormat(targetFormat)
+
+		rootOffsets: AccessPath
+		rootOffsets.valid = true
+
+		key("global scope")
+		{
+			SCOPED_OBJECT()
+			printScope(sp.program_layout_getGlobalParamsVarLayout(programLayout), rootOffsets)
+		}
+
+		key("entry points")
+		entryPointCount := sp.program_layout_getEntryPointCount(programLayout)
+		
+		WITH_ARRAY(); for i in 0..<entryPointCount {
+			element()
+			printEntryPointLayout(sp.program_layout_getEntryPointByIndex(programLayout, i), rootOffsets)
+		}
+	}
+	clear(&g_metadataForEntryPoints)
+	shrink(&g_metadataForEntryPoints)
+}
+
+printEntryPointLayout :: proc(
+	entryPointLayout: ^sp.EntryPointReflection,
+	accessPath:       AccessPath,
+) {
+	SCOPED_OBJECT()
+
+	key("stage")
+	printStage(sp.entry_point_getStage(entryPointLayout))
+
+	printStageSpecificInfo(entryPointLayout)
+
+	printScope(sp.entry_point_getVarLayout(entryPointLayout), accessPath)
+
+	resultVariableLayout := sp.entry_point_getResultVarLayout(entryPointLayout)
+	cond := sp.type_layout_getKind(sp.variable_layout_getTypeLayout(resultVariableLayout)) != .None
+	if cond {
+		key("result")
+		printVariableLayout(resultVariableLayout, accessPath)
+	}
+}
+
+// #### Stage-Specific Information
+//
+printStageSpecificInfo :: proc(entryPointLayout: ^sp.EntryPointReflection) {
+	#partial switch (sp.entry_point_getStage(entryPointLayout)) {
+	case:
+	case .COMPUTE:
+		kAxisCount :: 3
+		sizes: [kAxisCount]uint
+		sp.entry_point_getComputeThreadGroupSize(entryPointLayout, kAxisCount, &sizes[0])
+
+		key("thread group size")
+		SCOPED_OBJECT()
+		key("x")
+		print(sizes[0])
+		key("y")
+		print(sizes[1])
+		key("z")
+		print(sizes[2])
+	case .FRAGMENT:
+		key("uses any sample-rate inputs")
+		printBool(sp.entry_point_usesAnySampleRateInput(entryPointLayout))
+	}
+}
+
+collectEntryPointMetadata :: proc(
+	program: ^sp.IComponentType,
+	targetIndex: int,
+	entryPointCount: int
+) -> sp.Result {
+	resize(&g_metadataForEntryPoints, entryPointCount)
+	for entryPointIndex in 0..< entryPointCount {
+		entryPointMetadata: ^sp.IMetadata
+		diags: ^sp.IBlob
+		result := program->getEntryPointMetadata(
+			entryPointIndex,
+			targetIndex,
+			&entryPointMetadata,
+			&diags,
+		)
+		ex.diagnostics_check(diags)
+		if sp.FAILED(result) do return result
+
+		g_metadataForEntryPoints[entryPointIndex] = entryPointMetadata
+	}
+	return sp.OK
+}
+
+compileAndReflectPrograms :: proc(session: ^sp.ISession) -> (result: sp.Result){
+	result = sp.OK
+	g_afterArrayElement = true
+	WITH_ARRAY(); for fileName in g_SourceFileNames {
+		element()
+		programResult := compileAndReflectProgram(session, fileName)
+		if sp.FAILED(programResult) do return programResult
+	}
+
+	newLine()
+	return
+
+}
+
+compileAndReflectProgram :: proc(session: ^sp.ISession, sourceFileName: cstring) -> (result: sp.Result) {
+	g_afterArrayElement = false
+	SCOPED_OBJECT()
+	printComment("program")
+	key("file name")
+	printQuotedString(sourceFileName)
+	sourceFilePath := sourceFileName
+
+	diags: ^sp.IBlob
+	result = sp.OK
+
+	module := session->loadModule(sourceFilePath, &diags)
+	ex.diagnostics_check(diags)
+	defer if diags != nil { diags->release() }
+
+	if module == nil do return sp.FAIL()
+
+	componentsToLink: [dynamic]^sp.IComponentType
+
+	key("global constants")
+	d := module->getModuleReflection()
+	WITH_ARRAY(); for idx in 0..<sp.decl_getChildrenCount(d) {
+		decl := sp.decl_getChild(d, idx)
+		if varDecl := sp.decl_asVariable(decl); varDecl != nil &&
+		      sp.variable_findModifier(varDecl, .Const) != nil &&
+		      sp.variable_findModifier(varDecl, .Static) != nil
+		{
+			element()
+			printVariable(varDecl)		
+		}
+	}
+
+	key("defined entry points")
+	definedEntryPointCount := module->getDefinedEntryPointCount()
+
+	WITH_ARRAY(); for i in 0..<definedEntryPointCount {
+		entryPoint: ^sp.IEntryPoint
+		_ = module->getDefinedEntryPoint(i, &entryPoint)
+
+		element()
+		SCOPED_OBJECT()
+		key("name")
+		printQuotedString(sp.function_getName(entryPoint->getFunctionReflection()))
+
+		append(&componentsToLink, entryPoint)
+	}
+
+	composed: ^sp.IComponentType
+	result = session->createCompositeComponentType(
+		raw_data(componentsToLink),
+		len(componentsToLink),
+		&composed,
+		&diags,
+	)
+	ex.diagnostics_check(diags)
+	
+
+	program: ^sp.IComponentType
+	result = composed->link(&program, &diags)
+	ex.diagnostics_check(diags)
+	if sp.FAILED(result) do return result
+
+	key("layouts")
+	kTargetCount := 1
+	WITH_ARRAY(); for targetIndex in 0..<kTargetCount {
+		element()
+
+		// ### Getting the Program Layout
+		//
+		programLayout := program->getLayout(targetIndex, &diags)
+		ex.diagnostics_check(diags)
+		if programLayout == nil {
+			result = sp.FAIL()
+			continue
+		}
+
+		ex.slang_check(collectEntryPointMetadata(
+			program, targetIndex, int(definedEntryPointCount)))
+
+		g_programLayout = programLayout
+		printProgramLayout(programLayout, .SPIRV)
+	}
+
+	return result
+}

--- a/example/reflection_api/raster-simple.slang
+++ b/example/reflection_api/raster-simple.slang
@@ -1,0 +1,88 @@
+// raster-simple.slang
+
+struct AssembledVertex
+{
+    float3 position : POSITION;
+    float3 normal   : NORMAL;
+    float2 uv       : TEXCOORD;
+};
+
+struct RasterVertex
+{
+    float3 worldPosition;
+    float3 worldNormal;
+    float2 uv;
+};
+
+struct Model
+{
+    float3x4 modelToWorld;
+    float3x4 modelToWorld_inverseTranspose;
+}
+
+struct Material
+{
+    Texture2D<float3> albedoMap;
+    Texture2D<float3> normalMap;
+    Texture2D<float> glossMap;
+    SamplerState sampler;
+    float2 uvScale;
+    float2 uvBias;
+}
+
+struct Camera
+{
+    float3x4 worldToView;
+    float3x4 worldToView_inverseTranspose;
+
+    float4x4 viewToProj;
+}
+
+struct DirectionalLight
+{
+    float3 intensity;
+    float3 direction;
+}
+
+struct Environment
+{
+    TextureCube environmentMap;
+    DirectionalLight light;
+}
+
+uniform Model                       model;
+uniform ParameterBlock<Material>    material;
+uniform ConstantBuffer<Camera>      camera;
+uniform ParameterBlock<Environment> environment;
+
+[shader("vertex")]
+[require(sm_6_0)]
+void vertexMain(
+    in AssembledVertex assembledVertex : A,
+    out RasterVertex rasterVertex : R,
+    in uint vertexID : SV_VertexID,
+    out float4 projPosition :  SV_Position)
+{
+    float3 worldPosition = mul(model.modelToWorld, float4(assembledVertex.position,1));
+
+    rasterVertex.worldPosition = worldPosition;
+    rasterVertex.worldNormal = mul(model.modelToWorld_inverseTranspose, float4(assembledVertex.normal,0));
+    rasterVertex.uv = assembledVertex.uv;
+
+    float3 viewPosition = mul(camera.worldToView, float4(worldPosition,1));
+    projPosition = mul(camera.viewToProj, float4(viewPosition,1));
+}
+
+[shader("fragment")]
+[require(sm_6_0)]
+float4 fragmentMain(
+    in RasterVertex vertex : R)
+    : SV_Target0
+{
+    float3 normal = vertex.worldNormal;
+
+    float3 albedo = material.albedoMap.Sample(material.sampler, vertex.uv);
+
+    float3 color = albedo * max(0, dot(normal, environment.light.direction));
+    return float4(color, 1);
+}

--- a/example/reflection_api/wrapper_example/wrapped_example.odin
+++ b/example/reflection_api/wrapper_example/wrapped_example.odin
@@ -1,0 +1,822 @@
+package reflection_wrapper_example
+
+import "core:fmt"
+
+import refl "../../../slang/reflection_wrapper"
+import sp "../../../slang"
+import ex "../../"
+
+// ported from https://github.com/shader-slang/slang/tree/master/examples/reflection-api
+
+main :: proc() {
+	global_session: ^sp.IGlobalSession
+	ensure(sp.createGlobalSession(sp.API_VERSION, &global_session) == sp.OK)
+	defer sp.shutdown()
+
+	target_desc := sp.TargetDesc {
+		structureSize = size_of(sp.TargetDesc),
+		format        = .SPIRV,
+		flags         = {.GENERATE_SPIRV_DIRECTLY},
+		profile       = global_session->findProfile("sm_6_0"),
+	}
+
+	session_desc := sp.SessionDesc {
+		structureSize            = size_of(sp.SessionDesc),
+		targets                  = &target_desc,
+		targetCount              = 1,
+	}
+
+	session: ^sp.ISession
+	global_session->createSession(session_desc, &session)
+	defer session->release() 
+
+	g_SourceFileNames = {
+		"../compute-simple.slang",
+		"../raster-simple.slang",
+	}
+
+	res := compileAndReflectPrograms(session)
+	ex.slang_check(res)
+	fmt.println("")
+}
+
+g_afterArrayElement: bool = true
+g_indentation: int
+g_metadataForEntryPoints: [dynamic]^sp.IMetadata
+g_programLayout: refl.ProgramLayout
+g_SourceFileNames: []cstring
+
+printIndentation :: proc() {
+	for _ in 1..<g_indentation {
+		print(" ")
+	}
+}
+
+common_print :: proc(args: ..any) {
+	fmt.print(..args)
+}
+
+printf             :: fmt.printf
+printResourceShape :: proc(shape: sp.SlangResourceShape) {
+	SCOPED_OBJECT()
+	key("base")
+	common_print(shape & .BASE_SHAPE_MASK)
+}
+printComment :: proc(args: ..any) {
+	printf("# %s",..args)
+}
+
+print                 :: common_print
+printBool             :: common_print
+printTypeKind         :: common_print
+printScalarType       :: common_print
+printResourceAccess   :: common_print
+printLayoutUnit       :: common_print
+printMatrixLayoutMode :: common_print
+printStage            :: common_print
+printTargetFormat     :: common_print
+
+StageMask :: bit_set[sp.Stage; u32]
+
+INDENT :: 4
+beginObject :: proc() { g_indentation += INDENT }
+endObject   :: proc() { g_indentation -= INDENT }
+beginArray  :: proc() { g_indentation += INDENT }
+endArray    :: proc() { g_indentation -= INDENT }
+
+@(deferred_none=endObject)
+SCOPED_OBJECT :: proc() {
+	beginObject()
+}
+
+@(deferred_none=endArray)
+WITH_ARRAY :: proc() {
+	beginArray()
+}
+
+newLine :: proc() {
+	print("\n")
+	printIndentation()
+}
+
+key :: proc(key: cstring) {
+	if !g_afterArrayElement {
+		newLine()
+	}
+	g_afterArrayElement = false
+
+	printf("%s: ", key)
+}
+
+element :: proc() {
+	newLine()
+	printf("- ")
+	g_afterArrayElement = true
+}
+
+printQuotedString :: proc(text: cstring) {
+	if text != "" {
+		printf("\"%s\"", text)
+	} else {
+		print("null")
+	}
+}
+
+printVariable :: proc(variable: refl.VariableReflection) {
+	SCOPED_OBJECT()
+
+	name := variable->getName()
+	type := variable->getType()
+
+	key("name")
+	printQuotedString(name)
+	key("type")
+	printType(type)
+
+	value: i64
+	if sp.SUCCEEDED(variable->getDefaultValueInt(&value)){
+		key("value")
+		print(value)
+	}
+}
+
+
+
+printCommonTypeInfo :: proc(type: refl.TypeReflection) {
+	#partial switch type->getKind() {
+	case .Scalar: 
+		key("scalar type")
+		printScalarType(type->getScalarType())
+	case .Array:
+		key("element count")
+		printPossiblyUnbounded(type->getElementCount())
+	case .Vector:
+		key("element count")
+		print(type->getElementCount())
+	case .Matrix:
+		key("row count")
+		print(type->getRowCount())
+		key("column count")
+		print(type->getColumnCount())
+	case .Resource:
+		key("shape")
+		printResourceShape(type->getResourceShape())
+		key("access")
+		printResourceAccess(type->getResourceAccess())
+	case:
+	}
+}
+
+
+
+printType :: proc(type: refl.TypeReflection) {
+	SCOPED_OBJECT()
+	name := type->getName()
+	kind := type->getKind()
+
+	key("name")
+	printQuotedString(name)
+	key("kind")
+	printTypeKind(kind)
+
+	printCommonTypeInfo(type)
+
+	#partial switch type->getKind() {
+	case .Struct:
+		key("fields")
+		fieldCount := type->getFieldCount()
+		
+		WITH_ARRAY(); for f in 0..<fieldCount {
+			element()
+			field := type->getFieldByIndex(f)
+			printVariable(field)
+		}
+	case .Array, .Vector, .Matrix:
+		key("element type")
+		printType(type->getElementType())
+	case .Resource:
+		key("result type")
+		printType(type->getResourceResultType())
+	case .ConstantBuffer, .ParameterBlock, .TextureBuffer, .ShaderStorageBuffer:
+	// "single-element containers" 
+	// https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/09-reflection.html#pitfalls-to-avoid    
+		key("element type")
+		printType(type->getElementType())
+	case:
+	}	
+}
+
+printPossiblyUnbounded :: proc(value: uint) {
+	if value == sp.UNBOUNDED_SIZE {
+		printf("unbounded")
+	} else {
+		printf("%d", value)
+	}
+}
+
+printVariableLayout :: proc(variableLayout: refl.VariableLayoutReflection, accessPath: AccessPath) {
+	SCOPED_OBJECT()
+
+	key("name")
+	printQuotedString(variableLayout->getName())
+
+	printOffsets(variableLayout, accessPath)
+
+	printVaryingParameterInfo(variableLayout)
+
+	variablePath: ExtendedAccessPath
+	initExtendedAccessPath(&variablePath, accessPath, variableLayout)
+
+	key("type layout")
+	printTypeLayout(variableLayout->getTypeLayout(), variablePath)
+}
+
+initExtendedAccessPath :: proc(
+	eap:            ^ExtendedAccessPath,
+	accessPath:     AccessPath,
+	variableLayout: refl.VariableLayoutReflection
+) {
+	if !accessPath.valid {
+		return 
+	}
+
+	eap.accessPath = accessPath
+	eap.element.variableLayout = variableLayout
+	eap.element.outer = accessPath.leaf
+	eap.leaf = &eap.element
+}
+
+AccessPath :: struct {
+	valid: bool,
+	deepestConstantBufer : ^AccessPathNode,
+	deepestParameterBlock: ^AccessPathNode,
+	leaf: ^AccessPathNode,
+}
+
+ExtendedAccessPath :: struct {
+	using accessPath: AccessPath,
+	element:          AccessPathNode,
+}
+
+AccessPathNode :: struct {
+	variableLayout: refl.VariableLayoutReflection,
+	outer:          ^AccessPathNode,
+}
+
+printVaryingParameterInfo :: proc(variableLayout: refl.VariableLayoutReflection) {
+	semanticName := variableLayout->getSemanticName()
+	if semanticName != "" {
+		key("semantic")
+		SCOPED_OBJECT()
+		key("name")
+		printQuotedString(semanticName)
+		key("index")
+		print(variableLayout->getSemanticIndex())
+	}
+}
+
+printCumulativeOffsets :: proc(
+	variableLayout: refl.VariableLayoutReflection,
+	accessPath: AccessPath,
+) {
+	key("cumulative")
+
+	usedLayoutUnitCount := variableLayout->getCategoryCount()
+	WITH_ARRAY(); for i in 0..<usedLayoutUnitCount {
+		element()
+		layoutUnit := variableLayout->getCategoryByIndex(i)
+		printCumulativeOffset(variableLayout, layoutUnit, accessPath)
+	}
+}	
+
+printCumulativeOffset :: proc(
+	variableLayout: refl.VariableLayoutReflection,
+	layoutUnit:     sp.LayoutUnit,
+	accessPath:     AccessPath
+) {
+	cumulativeOffset := calculateCumulativeOffset(variableLayout, layoutUnit, accessPath)
+	printOffset(layoutUnit, cumulativeOffset.value, cumulativeOffset.space)
+}
+
+CumulativeOffset :: struct {
+	value: uint,
+	space: uint,
+}
+
+calculateCumulativeOffset2 :: proc(
+	layoutUnit: sp.LayoutUnit,
+	accessPath: AccessPath,
+) -> CumulativeOffset {
+	result: CumulativeOffset
+	#partial switch layoutUnit {
+	// #### Layout Units That Don't Require Special Handling
+	//
+	case:
+		for node := accessPath.leaf; node != nil; node = node.outer {
+			result.value += node.variableLayout->getOffset(layoutUnit)
+		}
+	// #### Bytes
+	//
+	case .Uniform:
+		for node := accessPath.leaf; node != accessPath.deepestConstantBufer; node = node.outer {
+			result.value += node.variableLayout->getOffset(layoutUnit)
+		}
+	// #### Layout Units That Care About Spaces
+	//
+	case .ConstantBuffer, .ShaderResource, .UnorderedAccess, .SamplerState, .DescriptorTableSlot:
+		for node := accessPath.leaf; node != accessPath.deepestParameterBlock; node = node.outer {
+			result.value += node.variableLayout->getOffset(layoutUnit)
+			result.space += node.variableLayout->getBindingSpace(layoutUnit)
+		}
+		for node := accessPath.deepestParameterBlock; node != nil; node = node.outer {
+			result.space += node.variableLayout->getOffset(.SubElementRegisterSpace)
+		}
+	}
+	return result
+}
+
+calculateCumulativeOffset :: proc(
+	variableLayout: refl.VariableLayoutReflection,
+	layoutUnit:     sp.LayoutUnit,
+	accessPath:     AccessPath,
+) -> CumulativeOffset {
+	result := calculateCumulativeOffset2(layoutUnit, accessPath)
+	result.value += variableLayout->getOffset(layoutUnit)
+	result.space += variableLayout->getBindingSpace(layoutUnit)
+	return result
+}
+
+printOffsets :: proc(variableLayout: refl.VariableLayoutReflection, accessPath: AccessPath) {
+	key("offset")
+	{
+		SCOPED_OBJECT()
+		printRelativeOffsets(variableLayout)
+
+		if accessPath.valid {
+			printCumulativeOffsets(variableLayout, accessPath)
+		}
+	}
+
+
+	if accessPath.valid {
+		printStageUsage(variableLayout, accessPath)
+	}
+}
+
+calculateStageMask :: proc(
+	variableLayout: refl.VariableLayoutReflection,
+	accessPath: AccessPath,
+) -> StageMask {
+	mask: StageMask
+
+	usedLayoutUnitCount := variableLayout->getCategoryCount()
+	for i in 0..<usedLayoutUnitCount {
+		layoutUnit := variableLayout->getCategoryByIndex(i)
+		offset := calculateCumulativeOffset(variableLayout, layoutUnit, accessPath)
+
+		mask |= calculateParameterStageMask(layoutUnit, offset)
+	}
+
+	return mask
+}
+
+ calculateParameterStageMask :: proc(
+	layoutUnit: sp.LayoutUnit ,
+	offset: CumulativeOffset ,
+) -> StageMask {
+	mask := StageMask{}
+	entryPointCount := len(g_metadataForEntryPoints)
+	for i in 0..<entryPointCount {
+		isUsed := false
+		g_metadataForEntryPoints[i]->isParameterLocationUsed(
+			sp.SlangParameterCategory(layoutUnit),
+			offset.space,
+			offset.value,
+			&isUsed
+		)
+		if isUsed {
+			entryPointStage := g_programLayout->getEntryPointByIndex(uint(i))->getStage()
+			mask += {entryPointStage}
+		}
+	}
+	return mask
+}
+
+printStageUsage :: proc(variableLayout: refl.VariableLayoutReflection, accessPath: AccessPath) {
+	stageMask := calculateStageMask(variableLayout, accessPath)
+
+	key("used by stages")
+	WITH_ARRAY(); for stage in stageMask {
+		if stage in stageMask {
+			element()
+			printStage(stage)
+		}
+	}
+
+	g_afterArrayElement = false
+}
+
+printOffset :: proc {
+	printOffset1,
+	printOffset2,
+}
+
+printOffset1 :: proc(
+	variableLayout: refl.VariableLayoutReflection,
+	layoutUnit: sp.LayoutUnit
+) {
+	printOffset2(
+		layoutUnit,
+		variableLayout->getOffset(layoutUnit),
+		variableLayout->getBindingSpace(layoutUnit)
+	)
+}
+
+printOffset2 :: proc(layoutUnit: sp.LayoutUnit, offset, spaceOffset: uint) {
+	SCOPED_OBJECT()
+	key("value")
+	print(offset)
+	key("unit")
+	printLayoutUnit(layoutUnit)
+
+	// #### Spaces / Sets
+	#partial switch layoutUnit {
+	case .ConstantBuffer, .ShaderResource, .UnorderedAccess, .SamplerState, .DescriptorTableSlot:
+		key("space")
+		print(spaceOffset)
+	case:
+	}
+}
+
+printRelativeOffsets :: proc(variableLayout: refl.VariableLayoutReflection) {
+	key("relative")
+	usedLayoutUnitCount := variableLayout->getCategoryCount()
+	
+	WITH_ARRAY(); for i in 0..<usedLayoutUnitCount {
+		element()
+
+		layoutUnit := variableLayout->getCategoryByIndex(i)
+		printOffset(variableLayout, layoutUnit)
+	}
+}
+
+printKindSpecificInfo :: proc(typeLayout: refl.TypeLayoutReflection, accessPath: AccessPath) {
+	#partial switch typeLayout->getKind() {
+	case .Struct:
+		key("fields")
+		fieldCount := typeLayout->getFieldCount()
+		WITH_ARRAY(); for f in 0..<fieldCount {
+			element()
+			field := typeLayout->getFieldByIndex(f)
+			printVariableLayout(field, accessPath)
+		}
+	case .Array, .Vector:
+		key("element type layout")
+		printTypeLayout(typeLayout->getElementTypeLayout(), {})
+	case .Matrix:
+		// Note that the concepts of “row” and “column” as employed by Slang are the opposite of how Vulkan,
+		// SPIR-V, GLSL, and OpenGL use those terms. When Slang reflects a matrix as using row-major layout,
+		// the corresponding matrix in generated SPIR-V will have a ColMajor decoration.
+		// For an explanation of why these conventions differ, please see the relevant appendix.
+		// https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/a1-01-matrix-layout.html
+		key("matrix layout mode")
+		printMatrixLayoutMode(typeLayout->getMatrixLayoutMode())
+
+		key("element type layout")
+		printTypeLayout(typeLayout->getElementTypeLayout(), {})
+	case .ConstantBuffer, .ParameterBlock, .TextureBuffer, .ShaderStorageBuffer:
+		containerVarLayout := typeLayout->getContainerVarLayout()
+		elementVarLayout := typeLayout->getElementVarLayout()
+
+		innerOffsets := accessPath
+		innerOffsets.deepestConstantBufer = innerOffsets.leaf
+		if containerVarLayout->getTypeLayout()->getSize(.SubElementRegisterSpace) != 0 {
+			innerOffsets.deepestParameterBlock = innerOffsets.leaf
+		}
+
+		key("container")
+		{
+			SCOPED_OBJECT()
+			printOffsets(containerVarLayout, innerOffsets)
+		}
+
+		key("content")
+		{
+			SCOPED_OBJECT()
+			printOffsets(elementVarLayout, innerOffsets)
+
+			elementOffsets: ExtendedAccessPath
+			initExtendedAccessPath(&elementOffsets, innerOffsets, elementVarLayout)
+
+			key("type layout")
+			printTypeLayout(elementVarLayout->getTypeLayout(), elementOffsets)
+		}
+	case .Resource:
+		resource_shape := typeLayout->getResourceShape()
+		if u32(resource_shape & .BASE_SHAPE_MASK) ==
+			u32(sp.SlangResourceShape(.STRUCTURED_BUFFER)) {
+			key("element type layout")
+			printTypeLayout(typeLayout->getElementTypeLayout(), accessPath)
+		} else {
+			key("result type")
+			printType(typeLayout->getResourceResultType())
+		}	
+	case: 
+	}
+}
+
+printTypeLayout :: proc(typeLayout: refl.TypeLayoutReflection, accessPath: AccessPath) {
+	SCOPED_OBJECT()
+
+	key("name")
+	printQuotedString(typeLayout->getName())
+	key("kind")
+	printTypeKind(typeLayout->getKind())
+	printCommonTypeInfo(typeLayout->getType())
+
+	printSizes(typeLayout)
+
+	printKindSpecificInfo(typeLayout, accessPath)
+
+}
+
+printSize :: proc {
+	printSize1,
+	printSize2,
+}
+
+printSize1 :: proc(typeLayout: refl.TypeLayoutReflection, layoutUnit: sp.LayoutUnit) {
+	printSize(layoutUnit, typeLayout->getSize(layoutUnit))
+}
+
+printSize2 :: proc(layoutUnit: sp.LayoutUnit, size: uint) {
+	SCOPED_OBJECT()
+
+	key("value")
+	printPossiblyUnbounded(size)
+	key("unit")
+	printLayoutUnit(layoutUnit)
+}
+
+printSizes :: proc(typeLayout: refl.TypeLayoutReflection) {
+	key("size")
+	usedLayoutUnitCount := typeLayout->getCategoryCount()
+	
+	WITH_ARRAY(); for i in 0..<usedLayoutUnitCount {
+		element()
+
+		layoutUnit := typeLayout->getCategoryByIndex(i)
+		printSize(typeLayout, layoutUnit)
+	}
+}
+
+// ### Global Scope
+//
+printScope :: proc(scopeVarLayout: refl.VariableLayoutReflection, accessPath: AccessPath) {
+	scopeOffsets: ExtendedAccessPath
+	initExtendedAccessPath(&scopeOffsets, accessPath, scopeVarLayout)
+
+	scopeTypeLayout := scopeVarLayout->getTypeLayout()
+	#partial switch scopeTypeLayout->getKind() {
+	// #### Parameters are Grouped Into a Structure
+	//
+	case .Struct:
+		key("parameters")
+
+		paramCount := scopeTypeLayout->getFieldCount()
+		for i in 0..<paramCount {
+			element()
+			param := scopeTypeLayout->getFieldByIndex(i)
+			printVariableLayout(param, scopeOffsets)
+		}
+	
+
+	// #### Wrapped in a Constant Buffer If Needed
+	//
+	case .ConstantBuffer:
+		key("automatically-introduced constant buffer")
+		{
+			SCOPED_OBJECT()
+			printOffsets(scopeTypeLayout->getContainerVarLayout(), scopeOffsets)
+		}
+
+		printScope(scopeTypeLayout->getElementVarLayout(), scopeOffsets)
+
+	// #### Wrapped in a Parameter Block If Needed
+	//
+	case .ParameterBlock:
+		key("automatically-introduced parameter block")
+		{
+			SCOPED_OBJECT()
+			printOffsets(scopeTypeLayout->getContainerVarLayout(), scopeOffsets)
+		}
+
+		printScope(scopeTypeLayout->getElementVarLayout(), scopeOffsets)
+
+	case:
+	// Note that this default case is never expected to
+	// arise with the current Slang compiler and reflection
+	// API, but we include it here as a kind of failsafe.
+	//
+		key("variable layout")
+		printVariableLayout(scopeVarLayout, accessPath)
+	}
+
+}
+
+printProgramLayout :: proc(programLayout: refl.ProgramLayout, targetFormat: sp.CompileTarget) {
+	{
+		SCOPED_OBJECT()
+
+		key("target")
+		printTargetFormat(targetFormat)
+
+		rootOffsets: AccessPath
+		rootOffsets.valid = true
+
+		key("global scope")
+		{
+			SCOPED_OBJECT()
+			printScope(programLayout->getGlobalParamsVarLayout(), rootOffsets)
+		}
+
+		key("entry points")
+		entryPointCount := programLayout->getEntryPointCount()
+		
+		WITH_ARRAY(); for i in 0..<entryPointCount {
+			element()
+			printEntryPointLayout(programLayout->getEntryPointByIndex(i), rootOffsets)
+		}
+	}
+	clear(&g_metadataForEntryPoints)
+	shrink(&g_metadataForEntryPoints)
+}
+
+printEntryPointLayout :: proc(
+	entryPointLayout: refl.EntryPointReflection,
+	accessPath:       AccessPath,
+) {
+	SCOPED_OBJECT()
+
+	key("stage")
+	printStage(entryPointLayout->getStage())
+
+	printStageSpecificInfo(entryPointLayout)
+
+	printScope(entryPointLayout->getVarLayout(), accessPath)
+
+	resultVariableLayout := entryPointLayout->getResultVarLayout()
+	cond := resultVariableLayout->getTypeLayout()->getKind() != .None
+	if cond {
+		key("result")
+		printVariableLayout(resultVariableLayout, accessPath)
+	}
+}
+
+// #### Stage-Specific Information
+//
+printStageSpecificInfo :: proc(entryPointLayout: refl.EntryPointReflection) {
+	#partial switch (entryPointLayout->getStage()) {
+	case:
+	case .COMPUTE:
+		kAxisCount :: 3
+		sizes: [kAxisCount]uint
+		entryPointLayout->getComputeThreadGroupSize(kAxisCount, &sizes[0])
+
+		key("thread group size")
+		SCOPED_OBJECT()
+		key("x")
+		print(sizes[0])
+		key("y")
+		print(sizes[1])
+		key("z")
+		print(sizes[2])
+	case .FRAGMENT:
+		key("uses any sample-rate inputs")
+		printBool(entryPointLayout->usesAnySampleRateInput())
+	}
+}
+
+collectEntryPointMetadata :: proc(
+	program: ^sp.IComponentType,
+	targetIndex: int,
+	entryPointCount: int
+) -> sp.Result {
+	resize(&g_metadataForEntryPoints, entryPointCount)
+	for entryPointIndex in 0..< entryPointCount {
+		entryPointMetadata: ^sp.IMetadata
+		diags: ^sp.IBlob
+		result := program->getEntryPointMetadata(
+			entryPointIndex,
+			targetIndex,
+			&entryPointMetadata,
+			&diags,
+		)
+		ex.diagnostics_check(diags)
+		if sp.FAILED(result) do return result
+
+		g_metadataForEntryPoints[entryPointIndex] = entryPointMetadata
+	}
+	return sp.OK
+}
+
+compileAndReflectPrograms :: proc(session: ^sp.ISession) -> (result: sp.Result){
+	result = sp.OK
+	g_afterArrayElement = true
+	WITH_ARRAY(); for fileName in g_SourceFileNames {
+		element()
+		programResult := compileAndReflectProgram(session, fileName)
+		if sp.FAILED(programResult) do return programResult
+	}
+
+	newLine()
+	return
+
+}
+
+compileAndReflectProgram :: proc(session: ^sp.ISession, sourceFileName: cstring) -> (result: sp.Result) {
+	g_afterArrayElement = false
+	SCOPED_OBJECT()
+	printComment("program")
+	key("file name")
+	printQuotedString(sourceFileName)
+	sourceFilePath := sourceFileName
+
+	diags: ^sp.IBlob
+	result = sp.OK
+
+	module := session->loadModule(sourceFilePath, &diags)
+	ex.diagnostics_check(diags)
+	defer if diags != nil { diags->release() }
+
+	if module == nil do return sp.FAIL()
+
+	componentsToLink: [dynamic]^sp.IComponentType
+
+	key("global constants")
+	base_decl := refl.init_decl(module->getModuleReflection())
+	WITH_ARRAY(); for idx in 0..<base_decl->getChildrenCount() {
+		decl := base_decl->getChild(idx)
+		if varDecl := decl->asVariable(); varDecl != {} &&
+			varDecl->findModifier(.Const) != nil &&
+			varDecl->findModifier(.Static) != nil 
+			{
+			element()
+			printVariable(varDecl)		
+		}
+	}
+
+	key("defined entry points")
+	definedEntryPointCount := module->getDefinedEntryPointCount()
+
+	WITH_ARRAY(); for i in 0..<definedEntryPointCount {
+		entryPoint: ^sp.IEntryPoint
+		_ = module->getDefinedEntryPoint(i, &entryPoint)
+
+		element()
+		SCOPED_OBJECT()
+		key("name")
+		functionReflection := refl.init_function(entryPoint->getFunctionReflection())
+		printQuotedString(functionReflection->getName())
+
+		append(&componentsToLink, entryPoint)
+	}
+
+	composed: ^sp.IComponentType
+	result = session->createCompositeComponentType(
+		raw_data(componentsToLink),
+		len(componentsToLink),
+		&composed,
+		&diags,
+	)
+	ex.diagnostics_check(diags)
+	
+
+	program: ^sp.IComponentType
+	result = composed->link(&program, &diags)
+	ex.diagnostics_check(diags)
+	if sp.FAILED(result) do return result
+
+	key("layouts")
+	kTargetCount := 1
+	WITH_ARRAY(); for targetIndex in 0..<kTargetCount {
+		element()
+
+		// ### Getting the Program Layout
+		//
+		programLayout := program->getLayout(targetIndex, &diags)
+		ex.diagnostics_check(diags)
+		if programLayout == nil {
+			result = sp.FAIL()
+			continue
+		}
+
+		ex.slang_check(collectEntryPointMetadata(
+			program, targetIndex, int(definedEntryPointCount)))
+
+		g_programLayout = refl.init_program_layout(programLayout)
+		printProgramLayout(g_programLayout, .SPIRV)
+	}
+
+	return result
+}

--- a/slang/deprecated.odin
+++ b/slang/deprecated.odin
@@ -1,5 +1,104 @@
 package slang
 
-ICompileRequest :: struct #raw_union {
+SlangReflection :: ShaderReflection
 
+DiagnosticFlags :: enum i32 {
+	VERBOSE_PATHS = 0x01,
+	TREAT_WARNINGS_AS_ERRORS = 0x02,
+}
+
+Severity :: enum i32 {
+	DISABLED = 0, /**< A message that is disabled, filtered out. */
+	NOTE,         /**< An informative message. */
+	WARNING,      /**< A warning, which indicates a possible problem. */
+	ERROR,        /**< An error, indicating that compilation failed. */
+	FATAL,        /**< An unrecoverable error, which forced compilation to abort. */
+	INTERNAL,     /**< An internal error, indicating a logic error in the compiler.*/
+}
+
+ICompileRequest :: struct #raw_union {
+	#subtype iunknown: IUnknown,
+	using vtable: ^struct {
+		using iunknown_vtable: IUnknown_VTable,
+		setFileSystem:               proc "system"(this: ^ICompileRequest, fileSystem: ^IFileSystem,),
+		setCompileFlags:             proc "system"(this: ^ICompileRequest, flags: CompileFlags,),
+		getCompileFlags:             proc "system"(this: ^ICompileRequest,) -> CompileFlags,
+		setDumpIntermediates:        proc "system"(this: ^ICompileRequest, enable: i32,),
+		setDumpIntermediatePrefix:   proc "system"(this: ^ICompileRequest, prefix: cstring,),
+		setLineDirectiveMode:        proc "system"(this: ^ICompileRequest, mode: LineDirectiveMode,),
+		setCodeGenTarget:            proc "system"(this: ^ICompileRequest, target: CompileTarget,),
+		addCodeGenTarget:            proc "system"(this: ^ICompileRequest,target: CompileTarget,) -> i32,
+		setTargetProfile:            proc "system"(this: ^ICompileRequest,targetIndex: i32, profile: ProfileID,),
+		setTargetFlags:              proc "system"(this: ^ICompileRequest,targetIndex: i32, flags: TargetFlags,),
+		setTargetFloatingPointMode:  proc "system"(this: ^ICompileRequest,targetIndex: i32, mode: FloatingPointMode,),
+		setTargetMatrixLayoutMode:   proc "system"(this: ^ICompileRequest,targetIndex: i32, mode: MatrixLayoutMode,),
+		setMatrixLayoutMode:         proc "system"(this: ^ICompileRequest, mode: MatrixLayoutMode,),
+		setDebugInfoLevel:           proc "system"(this: ^ICompileRequest, level: DebugInfoLevel,),
+		setOptimizationLevel:        proc "system"(this: ^ICompileRequest, level: OptimizationLevel,),
+		setOutputContainerFormat:    proc "system"(this: ^ICompileRequest, format: ContainerFormat,),
+		setPassThrough:              proc "system"(this: ^ICompileRequest, passThrough: PassThrough,),
+		setDiagnosticCallback:       proc "system"(this: ^ICompileRequest,callback: DiagnosticCallback, userData: rawptr,),
+		setWriter:                   proc "system"(this: ^ICompileRequest,channel: WriterChannel, writer: ^IWriter,),
+		getWriter:                   proc "system"(this: ^ICompileRequest,channel: WriterChannel,) -> ^IWriter,
+		addSearchPath:               proc "system"(this: ^ICompileRequest, searchDir: cstring,),
+		addPreprocessorDefine:       proc "system"(this: ^ICompileRequest,key: cstring, value: cstring,),
+		processCommandLineArguments: proc "system"(this: ^ICompileRequest,args: [^]cstring,argCount: i32,) -> Result,
+		addTranslationUnit:          proc "system"(this: ^ICompileRequest,language: SourceLanguage,name: cstring,) -> i32,
+		setDefaultModuleName:        proc "system"(this: ^ICompileRequest, defaultModuleName: cstring,),
+		addTranslationUnitPreprocessorDefine: proc "system"(this: ^ICompileRequest,translationUnitIndex: i32,key: cstring, value: cstring,),
+		addTranslationUnitSourceFile:         proc "system"(this: ^ICompileRequest,translationUnitIndex: i32, path: cstring,),
+		addTranslationUnitSourceString:       proc "system"(this: ^ICompileRequest,translationUnitIndex: i32,path: cstring, source: cstring,),
+		addLibraryReference:                  proc "system"(this: ^ICompileRequest,basePath: cstring,libData: rawptr,libDataSize: uint,) -> Result,
+		addTranslationUnitSourceStringSpan:   proc "system"(this: ^ICompileRequest,translationUnitIndex: i32,path: cstring,sourceBegin: cstring, sourceEnd: cstring,),
+		addTranslationUnitSourceBlob:         proc "system"(this: ^ICompileRequest,translationUnitIndex: i32,path: cstring, sourceBlob: ^IBlob,),
+		addEntryPoint:               proc "system"(this: ^ICompileRequest,translationUnitIndex: i32,name: cstring,stage: Stage,) -> i32,
+		addEntryPointEx:             proc "system"(this: ^ICompileRequest,translationUnitIndex: i32,name: cstring,stage: Stage,genericArgCount: i32,genericArgs: [^]cstring,) -> i32,
+		setGlobalGenericArgs:        proc "system"(this: ^ICompileRequest,genericArgCount: i32,genericArgs: [^]cstring,) -> Result,
+		setTypeNameForGlobalExistentialTypeParam:     proc "system"(this: ^ICompileRequest,slotIndex: i32,typeName: cstring,) -> Result,
+		setTypeNameForEntryPointExistentialTypeParam: proc "system"(this: ^ICompileRequest,entryPointIndex: i32,slotIndex: i32,typeName: cstring,) -> Result,
+		setAllowGLSLInput:           proc "system"(this: ^ICompileRequest, value: bool,),
+		compile:                     proc "system"(this: ^ICompileRequest,) -> Result,
+		getDiagnosticOutput:         proc "system"(this: ^ICompileRequest,) -> cstring,
+		getDiagnosticOutputBlob:     proc "system"(this: ^ICompileRequest,outBlob: ^^IBlob,) -> Result,
+		getDependencyFileCount:      proc "system"(this: ^ICompileRequest,) -> i32,
+		getDependencyFilePath:       proc "system"(this: ^ICompileRequest,index: i32,) -> cstring,
+		getTranslationUnitCount:     proc "system"(this: ^ICompileRequest,) -> i32,
+		getEntryPointSource:         proc "system"(this: ^ICompileRequest,entryPointIndex: i32,) -> cstring,
+		getEntryPointCode:           proc "system"(this: ^ICompileRequest,entryPointIndex: i32,outSize: ^uint,) -> rawptr,
+		getEntryPointCodeBlob:       proc "system"(this: ^ICompileRequest,entryPointIndex: i32,targetIndex: i32,outBlob: ^^IBlob,) -> Result,
+		getEntryPointHostCallable:   proc "system"(this: ^ICompileRequest,entryPointIndex: i32,targetIndex: i32,outSharedLibrary: ^^ISharedLibrary,) -> Result,
+		getTargetCodeBlob:           proc "system"(this: ^ICompileRequest,targetIndex: i32,outBlob: ^^IBlob,) -> Result,
+		getTargetHostCallable:       proc "system"(this: ^ICompileRequest,targetIndex: i32,outSharedLibrary: ^^ISharedLibrary,) -> Result,
+		getCompileRequestCode:       proc "system"(this: ^ICompileRequest,outSize: ^uint,) -> rawptr,
+		getCompileRequestResultAsFileSystem: proc "system"(this: ^ICompileRequest,) -> ^IMutableFileSystem,
+		getContainerCode:            proc "system"(this: ^ICompileRequest,outBlob: ^^IBlob,) -> Result,
+		loadRepro:                   proc "system"(this: ^ICompileRequest,fileSystem: ^IFileSystem,data: rawptr,size: uint,) -> Result,
+		saveRepro:                   proc "system"(this: ^ICompileRequest,outBlob: ^^IBlob,) -> Result,
+		enableReproCapture:          proc "system"(this: ^ICompileRequest,) -> Result,
+		getProgram:                  proc "system"(this: ^ICompileRequest,outProgram: ^^IComponentType,) -> Result,
+		getEntryPoint:               proc "system"(this: ^ICompileRequest,entryPointIndex: Int,outEntryPoint: ^^IComponentType,) -> Result,
+		getModule:                   proc "system"(this: ^ICompileRequest,translationUnitIndex: Int,outModule: ^^IModule,) -> Result,
+		getSession:                  proc "system"(this: ^ICompileRequest,outSession: ^^ISession,) -> Result,
+		getReflection:               proc "system"(this: ^ICompileRequest,) -> ^SlangReflection,
+		addTargetCapability:         proc "system"(this: ^ICompileRequest,targetIndex: Int,capability: CapabilityID,) -> Result,
+		getProgramWithEntryPoints:   proc "system"(this: ^ICompileRequest,outProgram: ^^IComponentType,) -> Result,
+		isParameterLocationUsed:     proc "system"(this: ^ICompileRequest,entryPointIndex: Int,targetIndex: Int,category: ParameterCategory,spaceIndex: UInt,registerIndex: UInt,outUsed: ^bool,) -> Result,
+		setTargetLineDirectiveMode:  proc "system"(this: ^ICompileRequest,targetIndex: Int, mode: LineDirectiveMode,),
+		setTargetForceGLSLScalarBufferLayout: proc "system"(this: ^ICompileRequest,targetIndex: i32, forceScalarLayout: bool,),
+		overrideDiagnosticSeverity:  proc "system"(this: ^ICompileRequest,messageID: Int, overrideSeverity: Severity,),
+		getDiagnosticFlags:          proc "system"(this: ^ICompileRequest,) -> DiagnosticFlags,
+		setDiagnosticFlags:          proc "system"(this: ^ICompileRequest, flags: DiagnosticFlags,),
+		setDebugInfoFormat:          proc "system"(this: ^ICompileRequest, debugFormat: DebugInfoFormat,),
+		setEnableEffectAnnotations:  proc "system"(this: ^ICompileRequest, value: bool,),
+		setReportDownstreamTime:     proc "system"(this: ^ICompileRequest, value: bool,),
+		setReportPerfBenchmark:      proc "system"(this: ^ICompileRequest, value: bool,),
+		setSkipSPIRVValidation:      proc "system"(this: ^ICompileRequest, value: bool,),
+		setTargetUseMinimumSlangOptimization: proc "system"(this: ^ICompileRequest,targetIndex: i32, value: bool,),
+		setIgnoreCapabilityCheck:      proc "system"(this: ^ICompileRequest, value: bool,),
+		getCompileTimeProfile:         proc "system"(this: ^ICompileRequest,compileTimeProfile: ^^IProfiler,shouldClear: bool,) -> Result,
+		setTargetGenerateWholeProgram: proc "system"(this: ^ICompileRequest,targetIndex: i32, value: bool,),
+		setTargetForceDXLayout:        proc "system"(this: ^ICompileRequest,targetIndex: i32, value: bool,),
+		setTargetEmbedDownstreamIR:    proc "system"(this: ^ICompileRequest,targetIndex: i32, value: bool,),
+		setTargetForceCLayout:         proc "system"(this: ^ICompileRequest,targetIndex: i32, value: bool,),
+	},
 }

--- a/slang/reflection.odin
+++ b/slang/reflection.odin
@@ -1,0 +1,551 @@
+package slang
+
+when ODIN_OS == .Windows {
+	foreign import libslang "lib/slang.lib"
+} else when ODIN_OS == .Darwin {
+	foreign import libslang "lib/libslang.dylib"
+} else when ODIN_OS == .Linux {
+	foreign import libslang "lib/libslang.so"
+}
+_ :: libslang
+
+// Opaque handles
+ProgramLayout            :: ShaderReflection
+ShaderReflection         :: struct {}
+EntryPointReflection     :: struct {}
+
+VariableReflection       :: struct {}
+VariableLayoutReflection :: struct {}
+TypeReflection           :: struct {}
+TypeLayoutReflection     :: struct {}
+
+FunctionReflection       :: struct {}
+DeclReflection           :: struct {}
+
+Attribute                :: struct {}
+TypeParameterReflection  :: struct {}
+GenericReflection        :: struct {}
+GenericArgType           :: struct {}
+
+SlangReflectionGenericArg :: struct #raw_union {
+	typeVal: ^TypeReflection,
+	intVal:  ^i64,
+	boolVal: bool,
+}
+
+ReflectionGenericArgType :: enum i32 {
+	TYPE,
+	INT,
+	BOOL,
+}
+
+Modifier :: struct {
+	id: ModifierID,
+}
+ModifierID :: enum u32 {
+	Shared         = u32(SlangModifierID(.SHARED)),
+	NoDiff         = u32(SlangModifierID(.NO_DIFF)),
+	Static         = u32(SlangModifierID(.STATIC)),
+	Const          = u32(SlangModifierID(.CONST)),
+	Export         = u32(SlangModifierID(.EXPORT)),
+	Extern         = u32(SlangModifierID(.EXTERN)),
+	Differentiable = u32(SlangModifierID(.DIFFERENTIABLE)),
+	Mutating       = u32(SlangModifierID(.MUTATING)),
+	In             = u32(SlangModifierID(.IN)),
+	Out            = u32(SlangModifierID(.OUT)),
+	InOut          = u32(SlangModifierID(.INOUT)),
+}
+
+SlangModifierID :: enum u32 {
+	SHARED,
+	NO_DIFF,
+	STATIC,
+	CONST,
+	EXPORT,
+	EXTERN,
+	DIFFERENTIABLE,
+	MUTATING,
+	IN,
+	OUT,
+	INOUT,
+}
+
+LayoutUnit        :: ParameterCategory
+ParameterCategory :: enum u32 {
+	None                       = u32(SlangParameterCategory(.NONE)),
+	Mixed                      = u32(SlangParameterCategory(.MIXED)),
+	ConstantBuffer             = u32(SlangParameterCategory(.CONSTANT_BUFFER)),
+	ShaderResource             = u32(SlangParameterCategory(.SHADER_RESOURCE)),
+	UnorderedAccess            = u32(SlangParameterCategory(.UNORDERED_ACCESS)),
+	VaryingInput               = u32(SlangParameterCategory(.VARYING_INPUT)),
+	VaryingOutput              = u32(SlangParameterCategory(.VARYING_OUTPUT)),
+	SamplerState               = u32(SlangParameterCategory(.SAMPLER_STATE)),
+	Uniform                    = u32(SlangParameterCategory(.UNIFORM)),
+	DescriptorTableSlot        = u32(SlangParameterCategory(.DESCRIPTOR_TABLE_SLOT)),
+	SpecializationConstant     = u32(SlangParameterCategory(.SPECIALIZATION_CONSTANT)),
+	PushConstantBuffer         = u32(SlangParameterCategory(.PUSH_CONSTANT_BUFFER)),
+	RegisterSpace              = u32(SlangParameterCategory(.REGISTER_SPACE)),
+	GenericResource            = u32(SlangParameterCategory(.GENERIC)),
+	RayPayload                 = u32(SlangParameterCategory(.RAY_PAYLOAD)),
+	HitAttributes              = u32(SlangParameterCategory(.HIT_ATTRIBUTES)),
+	CallablePayload            = u32(SlangParameterCategory(.CALLABLE_PAYLOAD)),
+	ShaderRecord               = u32(SlangParameterCategory(.SHADER_RECORD)),
+	ExistentialTypeParam       = u32(SlangParameterCategory(.EXISTENTIAL_TYPE_PARAM)),
+	ExistentialObjectParam     = u32(SlangParameterCategory(.EXISTENTIAL_OBJECT_PARAM)),
+	SubElementRegisterSpace    = u32(SlangParameterCategory(.SUB_ELEMENT_REGISTER_SPACE)),
+	InputAttachmentIndex       = u32(SlangParameterCategory(.SUBPASS)),
+	MetalBuffer                = u32(SlangParameterCategory(.CONSTANT_BUFFER)),
+	MetalTexture               = u32(SlangParameterCategory(.METAL_TEXTURE)),
+	MetalArgumentBufferElement = u32(SlangParameterCategory(.METAL_ARGUMENT_BUFFER_ELEMENT)),
+	MetalAttribute             = u32(SlangParameterCategory(.METAL_ATTRIBUTE)),
+	MetalPayload               = u32(SlangParameterCategory(.METAL_PAYLOAD)),
+	VertexInput                = u32(SlangParameterCategory(.VERTEX_INPUT)),
+	FragmentOutput             = u32(SlangParameterCategory(.FRAGMENT_OUTPUT)),
+}
+
+SlangParameterCategory :: enum u32 {
+	NONE,
+	MIXED,
+	CONSTANT_BUFFER,
+	SHADER_RESOURCE,
+	UNORDERED_ACCESS,
+	VARYING_INPUT,
+	VARYING_OUTPUT,
+	SAMPLER_STATE,
+	UNIFORM,
+	DESCRIPTOR_TABLE_SLOT,
+	SPECIALIZATION_CONSTANT,
+	PUSH_CONSTANT_BUFFER,
+	// HLSL register `space`, Vulkan GLSL `set`
+	REGISTER_SPACE,
+	// TODO: Ellie, Both APIs treat mesh outputs as more or less varying output,
+	// Does it deserve to be represented here??
+	// A parameter whose type is to be specialized by a global generic type argument
+	GENERIC,
+	RAY_PAYLOAD,
+	HIT_ATTRIBUTES,
+	CALLABLE_PAYLOAD,
+	SHADER_RECORD,
+	// An existential type parameter represents a "hole" that
+	// needs to be filled with a concrete type to enable
+	// generation of specialized code.
+	//
+	// Consider this example:
+	//
+	//      struct MyParams
+	//      {
+	//          IMaterial material;
+	//          ILight lights[3];
+	//      };
+	//
+	// This `MyParams` type introduces two existential type parameters:
+	// one for `material` and one for `lights`. Even though `lights`
+	// is an array, it only introduces one type parameter, because
+	// we need to hae a *single* concrete type for all the array
+	// elements to be able to generate specialized code.
+	//
+	EXISTENTIAL_TYPE_PARAM,
+	// An existential object parameter represents a value
+	// that needs to be passed in to provide data for some
+	// interface-type shader paameter.
+	//
+	// Consider this example:
+	//
+	//      struct MyParams
+	//      {
+	//          IMaterial material;
+	//          ILight lights[3];
+	//      };
+	//
+	// This `MyParams` type introduces four existential object parameters:
+	// one for `material` and three for `lights` (one for each array
+	// element). This is consistent with the number of interface-type
+	// "objects" that are being passed through to the shader.
+	//
+	EXISTENTIAL_OBJECT_PARAM,
+	// The register space offset for the sub-elements that occupies register spaces.
+	SUB_ELEMENT_REGISTER_SPACE,
+	// The input_attachment_index subpass occupancy tracker
+	SUBPASS,
+	// Metal tier-1 argument buffer element [[id]].
+	METAL_ARGUMENT_BUFFER_ELEMENT,
+	// Metal [[attribute]] inputs.
+	METAL_ATTRIBUTE,
+	// Metal [[payload]] inputs
+	METAL_PAYLOAD,
+
+	 //
+	COUNT,
+
+	 // Aliases for Metal-specific categories.
+	METAL_BUFFER = CONSTANT_BUFFER,
+	METAL_TEXTURE = SHADER_RESOURCE,
+	METAL_SAMPLER = SAMPLER_STATE,
+
+	 // DEPRECATED:
+	VERTEX_INPUT = VARYING_INPUT,
+	FRAGMENT_OUTPUT = VARYING_OUTPUT,
+	COUNT_V1 = SUBPASS,
+}
+
+TypeReflectionKind :: enum u32 {
+	None                 = u32(SlangTypeKind(.NONE)),
+	Struct               = u32(SlangTypeKind(.STRUCT)),
+	Array                = u32(SlangTypeKind(.ARRAY)),
+	Matrix               = u32(SlangTypeKind(.MATRIX)),
+	Vector               = u32(SlangTypeKind(.VECTOR)),
+	Scalar               = u32(SlangTypeKind(.SCALAR)),
+	ConstantBuffer       = u32(SlangTypeKind(.CONSTANT_BUFFER)),
+	Resource             = u32(SlangTypeKind(.RESOURCE)),
+	SamplerState         = u32(SlangTypeKind(.SAMPLER_STATE)),
+	TextureBuffer        = u32(SlangTypeKind(.TEXTURE_BUFFER)),
+	ShaderStorageBuffer  = u32(SlangTypeKind(.SHADER_STORAGE_BUFFER)),
+	ParameterBlock       = u32(SlangTypeKind(.PARAMETER_BLOCK)),
+	GenericTypeParameter = u32(SlangTypeKind(.GENERIC_TYPE_PARAMETER)),
+	Interface            = u32(SlangTypeKind(.INTERFACE)),
+	OutputStream         = u32(SlangTypeKind(.OUTPUT_STREAM)),
+	Specialized          = u32(SlangTypeKind(.SPECIALIZED)),
+	Feedback             = u32(SlangTypeKind(.FEEDBACK)),
+	Pointer              = u32(SlangTypeKind(.POINTER)),
+	DynamicResource      = u32(SlangTypeKind(.DYNAMIC_RESOURCE)),
+	MeshOutput           = u32(SlangTypeKind(.MESH_OUTPUT)),
+}
+
+SlangTypeKind :: enum u32 {
+	NONE,
+	STRUCT,
+	ARRAY,
+	MATRIX,
+	VECTOR,
+	SCALAR,
+	CONSTANT_BUFFER,
+	RESOURCE,
+	SAMPLER_STATE,
+	TEXTURE_BUFFER,
+	SHADER_STORAGE_BUFFER,
+	PARAMETER_BLOCK,
+	GENERIC_TYPE_PARAMETER,
+	INTERFACE,
+	OUTPUT_STREAM,
+	MESH_OUTPUT,
+	SPECIALIZED,
+	FEEDBACK,
+	POINTER,
+	DYNAMIC_RESOURCE,
+}
+
+TypeReflectionScalarType :: enum u32 {
+	None    = u32(SlangScalarType(.NONE)),
+	Void    = u32(SlangScalarType(.VOID)),
+	Bool    = u32(SlangScalarType(.BOOL)),
+	Int32   = u32(SlangScalarType(.INT32)),
+	UInt32  = u32(SlangScalarType(.UINT32)),
+	Int64   = u32(SlangScalarType(.INT64)),
+	UInt64  = u32(SlangScalarType(.UINT64)),
+	Float16 = u32(SlangScalarType(.FLOAT16)),
+	Float32 = u32(SlangScalarType(.FLOAT32)),
+	Float64 = u32(SlangScalarType(.FLOAT64)),
+	Int8    = u32(SlangScalarType(.INT8)),
+	UInt8   = u32(SlangScalarType(.UINT8)),
+	Int16   = u32(SlangScalarType(.INT16)),
+	UInt16  = u32(SlangScalarType(.UINT16)),
+}
+
+SlangScalarType :: enum u32 {
+	NONE,
+	VOID,
+	BOOL,
+	INT32,
+	UINT32,
+	INT64,
+	UINT64,
+	FLOAT16,
+	FLOAT32,
+	FLOAT64,
+	INT8,
+	UINT8,
+	INT16,
+	UINT16,
+	INTPTR,
+	UINTPTR,
+}
+
+
+
+SlangResourceShape :: enum u32 {
+	BASE_SHAPE_MASK              = 0x0F,
+	NONE                         = 0x00,
+	TEXTURE_1D                   = 0x01,
+	TEXTURE_2D                   = 0x02,
+	TEXTURE_3D                   = 0x03,
+	TEXTURE_CUBE                 = 0x04,
+	TEXTURE_BUFFER               = 0x05,
+	STRUCTURED_BUFFER            = 0x06,
+	BYTE_ADDRESS_BUFFER          = 0x07,
+	RESOURCE_UNKNOWN             = 0x08,
+	ACCELERATION_STRUCTURE       = 0x09,
+	TEXTURE_SUBPASS              = 0x0A,
+	RESOURCE_EXT_SHAPE_MASK      = 0x1F0,
+	TEXTURE_FEEDBACK_FLAG        = 0x10,
+	TEXTURE_SHADOW_FLAG          = 0x20,
+	TEXTURE_ARRAY_FLAG           = 0x40,
+	TEXTURE_MULTISAMPLE_FLAG     = 0x80,
+	TEXTURE_COMBINED_FLAG        = 0x100,
+	TEXTURE_1D_ARRAY             = TEXTURE_1D | TEXTURE_ARRAY_FLAG,
+	TEXTURE_2D_ARRAY             = TEXTURE_2D | TEXTURE_ARRAY_FLAG,
+	TEXTURE_CUBE_ARRAY           = TEXTURE_CUBE | TEXTURE_ARRAY_FLAG,
+	TEXTURE_2D_MULTISAMPLE       = TEXTURE_2D | TEXTURE_MULTISAMPLE_FLAG,
+	TEXTURE_2D_MULTISAMPLE_ARRAY = TEXTURE_2D | TEXTURE_MULTISAMPLE_FLAG | TEXTURE_ARRAY_FLAG,
+	TEXTURE_SUBPASS_MULTISAMPLE  = TEXTURE_SUBPASS | TEXTURE_MULTISAMPLE_FLAG,
+}
+
+SlangResourceAccess :: enum u32 {
+	NONE,
+	READ,
+	READ_WRITE,
+	RASTER_ORDERED,
+	APPEND,
+	CONSUME,
+	WRITE,
+	FEEDBACK,
+	UNKNOWN = 0x7FFFFFFF,
+}
+
+DeclKind :: enum u32 {
+	UNSUPPORTED_FOR_REFLECTION,
+	STRUCT,
+	FUNC,
+	MODULE,
+	GENERIC,
+	VARIABLE,
+	NAMESPACE,
+}
+
+BindingType :: enum u32 {
+	UNKNOWN = 0,
+	SAMPLER,
+	TEXTURE,
+	CONSTANT_BUFFER,
+	PARAMETER_BLOCK,
+	TYPED_BUFFER,
+	RAW_BUFFER,
+	COMBINED_TEXTURE_SAMPLER,
+	INPUT_RENDER_TARGET,
+	INLINE_UNIFORM_DATA,
+	RAY_TRACING_ACCELERATION_STRUCTURE,
+	VARYING_INPUT,
+	VARYING_OUTPUT,
+	EXISTENTIAL_VALUE,
+	PUSH_CONSTANT,
+	MUTABLE_FLAG = 0x100,
+
+	// TODO(Dragos): fix typo in main repo SLANG_BINDING_TYPE_MUTABLE_TETURE
+	MUTABLE_TEXTURE = TEXTURE | MUTABLE_FLAG,
+	MUTABLE_TYPED_BUFFER = TYPED_BUFFER | MUTABLE_FLAG,
+	MUTABLE_RAW_BUFFER = RAW_BUFFER | MUTABLE_FLAG,
+
+	BASE_MASK = 0x00FF,
+	EXT_MASK = 0xFF00,
+}
+
+@(link_prefix="sp")
+@(default_calling_convention="c")
+foreign libslang {
+	// Variable
+	ReflectionVariable_GetName :: proc(entryPoint: ^VariableReflection) -> cstring ---
+	ReflectionVariable_GetType :: proc(inVar: ^VariableReflection) -> ^TypeReflection ---
+	ReflectionVariable_FindModifier :: proc(inVar: ^VariableReflection, modifierID: SlangModifierID) -> ^Modifier ---
+	ReflectionVariable_GetUserAttributeCount :: proc(inVar: ^VariableReflection) -> u32 ---
+	ReflectionVariable_GetUserAttribute :: proc(inVar: ^VariableReflection, index: u32) -> ^Attribute ---
+	ReflectionVariable_FindUserAttributeByName :: proc(inVar: ^VariableReflection, session: ^IGlobalSession, name: cstring) -> ^Attribute ---
+	ReflectionVariable_HasDefaultValue :: proc(inVar: ^VariableReflection) -> bool ---
+	ReflectionVariable_GetDefaultValueInt :: proc(inVar: ^VariableReflection, rs: ^i64) -> Result ---
+	ReflectionVariable_GetGenericContainer :: proc(var: ^VariableReflection) -> ^GenericReflection ---
+	ReflectionVariable_applySpecializations :: proc(var: ^VariableReflection, generic: ^GenericReflection) -> ^VariableReflection ---
+
+	// Type
+  	ReflectionType_GetName :: proc(inType: ^TypeReflection) -> cstring ---
+	ReflectionType_GetFullName :: proc(inType: ^TypeReflection, outNameBlob: ^^IBlob) -> Result ---
+	ReflectionType_GetGenericContainer :: proc(inType: ^TypeReflection) -> ^GenericReflection ---
+	ReflectionType_GetResourceResultType :: proc(inType: ^TypeReflection) -> ^TypeReflection ---
+	ReflectionType_GetKind       :: proc(type: ^TypeReflection) -> SlangTypeKind ---
+	ReflectionType_GetFieldCount :: proc(type: ^TypeReflection) -> u32 ---
+	ReflectionType_GetFieldByIndex :: proc(inType: ^TypeReflection, index: u32) -> ^VariableReflection ---
+	ReflectionType_GetElementCount :: proc(inType: ^TypeReflection) -> uint ---
+	ReflectionType_GetSpecializedElementCount :: proc(inType: ^TypeReflection, reflection: ^ProgramLayout) -> uint ---
+	ReflectionType_GetElementType :: proc(inType: ^TypeReflection) -> ^TypeReflection ---
+	ReflectionType_GetRowCount :: proc(inType: ^TypeReflection) -> u32 ---
+	ReflectionType_GetColumnCount :: proc(inType: ^TypeReflection) -> u32 ---
+	ReflectionType_GetScalarType :: proc(inType: ^TypeReflection) -> SlangScalarType ---
+	ReflectionType_GetUserAttributeCount :: proc(inType: ^TypeReflection) -> u32 ---
+	ReflectionType_GetResourceShape :: proc(inType: ^TypeReflection) -> SlangResourceShape ---
+	ReflectionType_GetResourceAccess :: proc(inType: ^TypeReflection) -> SlangResourceAccess ---
+	ReflectionType_getSpecializedTypeArgCount :: proc(inType: ^TypeReflection) -> Int ---
+	ReflectionType_getSpecializedTypeArgType :: proc(inType: ^TypeReflection, index: Int) -> ^TypeReflection ---
+
+	// Program Layout
+	Reflection_FindFunctionByName :: proc(reflection: ^ProgramLayout, name: cstring) -> ^FunctionReflection ---
+	Reflection_FindFunctionByNameInType :: proc(reflection: ^ProgramLayout, reflType: ^TypeReflection, name: cstring) -> ^FunctionReflection ---
+	Reflection_FindVarByNameInType :: proc(reflection: ^ProgramLayout, reflType: ^TypeReflection, name: cstring) -> ^VariableReflection ---
+	Reflection_FindTypeByName :: proc(reflection: ^ProgramLayout, name: cstring) -> ^TypeReflection ---
+	Reflection_TryResolveOverloadedFunction :: proc(reflection: ^ProgramLayout, candidateCount: u32, candidates: ^^FunctionReflection,) -> ^FunctionReflection ---
+	Reflection_isSubType :: proc(reflection: ^ProgramLayout, subType: ^TypeReflection, superType: ^TypeReflection,) -> bool ---
+	Reflection_GetTypeLayout :: proc(reflection: ^ProgramLayout, inType: ^TypeReflection, rules: LayoutRules,) -> ^TypeLayoutReflection ---
+
+	ReflectionUserAttribute_GetName :: proc(attrib: ^Attribute) -> cstring ---
+	ReflectionUserAttribute_GetArgumentCount :: proc(attrib: ^Attribute) -> u32 ---
+	ReflectionUserAttribute_GetArgumentValueInt :: proc(attrib: ^Attribute, index: u32, rs: ^int) -> Result ---
+	ReflectionUserAttribute_GetArgumentValueFloat :: proc(attrib: ^Attribute, index: u32, rs: ^f32) -> Result ---
+	ReflectionUserAttribute_GetArgumentValueString :: proc(attrib: ^Attribute, index: u32, bufLen: ^uint) -> cstring ---
+
+	ReflectionTypeLayout_GetType :: proc(inTypeLayout: ^TypeLayoutReflection) -> ^TypeReflection ---
+	ReflectionTypeLayout_getKind :: proc(inTypeLayout: ^TypeLayoutReflection) -> SlangTypeKind ---
+	ReflectionTypeLayout_GetSize :: proc(inTypeLayout: ^TypeLayoutReflection, category: ParameterCategory) -> uint ---
+	ReflectionTypeLayout_GetStride :: proc(inTypeLayout: ^TypeLayoutReflection, category: ParameterCategory) -> uint ---
+	ReflectionTypeLayout_getAlignment :: proc(inTypeLayout: ^TypeLayoutReflection, category: ParameterCategory) -> i32 ---
+	ReflectionTypeLayout_GetFieldByIndex :: proc(inTypeLayout: ^TypeLayoutReflection, index: u32) -> ^VariableLayoutReflection ---
+	ReflectionTypeLayout_findFieldIndexByName :: proc(inTypeLayout: ^TypeLayoutReflection, nameBegin: cstring, nameEnd: cstring) -> Int ---
+	ReflectionTypeLayout_GetExplicitCounter :: proc(inTypeLayout: ^TypeLayoutReflection) -> ^VariableLayoutReflection ---
+	ReflectionTypeLayout_GetElementStride :: proc(inTypeLayout: ^TypeLayoutReflection, category: ParameterCategory) -> uint ---
+	ReflectionTypeLayout_GetElementTypeLayout :: proc(inTypeLayout: ^TypeLayoutReflection) -> ^TypeLayoutReflection ---
+	ReflectionTypeLayout_GetElementVarLayout :: proc(inTypeLayout: ^TypeLayoutReflection) -> ^VariableLayoutReflection ---
+	ReflectionTypeLayout_getContainerVarLayout :: proc(inTypeLayout: ^TypeLayoutReflection) -> ^VariableLayoutReflection ---
+	ReflectionTypeLayout_GetParameterCategory :: proc(inTypeLayout: ^TypeLayoutReflection) -> ParameterCategory ---
+	ReflectionTypeLayout_GetFieldCount :: proc(inTypeLayout: ^TypeLayoutReflection) -> u32 ---
+	ReflectionTypeLayout_GetCategoryCount :: proc(inTypeLayout: ^TypeLayoutReflection) -> u32 ---
+	ReflectionTypeLayout_GetCategoryByIndex :: proc(inTypeLayout: ^TypeLayoutReflection, index: u32) -> ParameterCategory ---
+	ReflectionTypeLayout_GetMatrixLayoutMode :: proc(inTypeLayout: ^TypeLayoutReflection) -> MatrixLayoutMode ---
+	ReflectionTypeLayout_getGenericParamIndex :: proc(inTypeLayout: ^TypeLayoutReflection) -> i32 ---
+	ReflectionTypeLayout_getPendingDataTypeLayout :: proc() -> ^TypeLayoutReflection ---
+	ReflectionTypeLayout_getSpecializedTypePendingDataVarLayout :: proc() -> ^VariableLayoutReflection ---
+	ReflectionTypeLayout_getBindingRangeCount :: proc(inTypeLayout: ^TypeLayoutReflection) -> Int ---
+	ReflectionTypeLayout_getBindingRangeType :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> BindingType ---
+	ReflectionTypeLayout_isBindingRangeSpecializable :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getBindingRangeBindingCount :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	// @(deprecated="commented out in slang now")
+	// ReflectionTypeLayout_getBindingRangeIndexOffset :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	// ReflectionTypeLayout_getBindingRangeSpaceOffset :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getBindingRangeLeafTypeLayout :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> ^TypeLayoutReflection ---
+	ReflectionTypeLayout_getBindingRangeLeafVariable :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> ^VariableReflection ---
+	ReflectionTypeLayout_getBindingRangeImageFormat :: proc(typeLayout: ^TypeLayoutReflection, index: Int) -> ImageFormat ---
+	ReflectionTypeLayout_getBindingRangeDescriptorSetIndex :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getBindingRangeFirstDescriptorRangeIndex :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getBindingRangeDescriptorRangeCount :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getDescriptorSetCount :: proc(inTypeLayout: ^TypeLayoutReflection) -> Int ---
+	ReflectionTypeLayout_getDescriptorSetSpaceOffset :: proc(inTypeLayout: ^TypeLayoutReflection, setIndex: Int) -> Int ---
+	ReflectionTypeLayout_getDescriptorSetDescriptorRangeCount :: proc(inTypeLayout: ^TypeLayoutReflection, setIndex: Int) -> Int ---
+	ReflectionTypeLayout_getDescriptorSetDescriptorRangeIndexOffset :: proc(inTypeLayout: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> Int ---
+	ReflectionTypeLayout_getDescriptorSetDescriptorRangeDescriptorCount :: proc(inTypeLayout: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> Int ---
+	ReflectionTypeLayout_getDescriptorSetDescriptorRangeType :: proc(inTypeLayout: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> BindingType ---
+	ReflectionTypeLayout_getDescriptorSetDescriptorRangeCategory :: proc(inTypeLayout: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> ParameterCategory ---
+	ReflectionTypeLayout_getSubObjectRangeSpaceOffset :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeOffset :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int) -> ^VariableLayoutReflection ---
+	ReflectionTypeLayout_getBindingRangeSubObjectRangeIndex :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getFieldBindingRangeOffset :: proc(inTypeLayout: ^TypeLayoutReflection, fieldIndex: Int) -> Int ---
+	ReflectionTypeLayout_getExplicitCounterBindingRangeOffset :: proc(inTypeLayout: ^TypeLayoutReflection) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeCount :: proc(inTypeLayout: ^TypeLayoutReflection) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeObjectCount :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeBindingRangeIndex :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeTypeLayout :: proc(inTypeLayout: ^TypeLayoutReflection, index: Int) -> ^TypeLayoutReflection ---
+	ReflectionTypeLayout_getSubObjectRangeDescriptorRangeCount :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeDescriptorRangeBindingType :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int, bindingRangeIndexInSubObject: Int) -> BindingType ---
+	ReflectionTypeLayout_getSubObjectRangeDescriptorRangeBindingCount :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int, bindingRangeIndexInSubObject: Int) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeDescriptorRangeIndexOffset :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int, bindingRangeIndexInSubObject: Int) -> Int ---
+	ReflectionTypeLayout_getSubObjectRangeDescriptorRangeSpaceOffset :: proc(inTypeLayout: ^TypeLayoutReflection, subObjectRangeIndex: Int, bindingRangeIndexInSubObject: Int) -> Int ---
+
+	ReflectionVariableLayout_GetVariable :: proc(inVarLayout: ^VariableLayoutReflection) -> ^VariableReflection ---
+	ReflectionVariableLayout_GetTypeLayout :: proc(inVarLayout: ^VariableLayoutReflection) -> ^TypeLayoutReflection ---
+	ReflectionVariableLayout_GetOffset :: proc(inVarLayout: ^VariableLayoutReflection, category: ParameterCategory) -> uint ---
+	ReflectionVariableLayout_GetSpace :: proc(inVarLayout: ^VariableLayoutReflection, category: ParameterCategory) -> uint ---
+	ReflectionVariableLayout_GetImageFormat :: proc(inVarLayout: ^VariableLayoutReflection) -> ImageFormat ---
+	ReflectionVariableLayout_GetSemanticName :: proc(inVarLayout: ^VariableLayoutReflection) -> cstring ---
+	ReflectionVariableLayout_GetSemanticIndex :: proc(inVarLayout: ^VariableLayoutReflection) -> uint ---
+	ReflectionVariableLayout_getStage :: proc(inVarLayout: ^VariableLayoutReflection) -> Stage ---
+	ReflectionVariableLayout_getPendingDataLayout :: proc() -> ^VariableLayoutReflection ---
+
+	ReflectionFunction_asDecl :: proc(inFunc: ^FunctionReflection) -> ^DeclReflection ---
+	ReflectionFunction_GetName :: proc(inFunc: ^FunctionReflection) -> cstring ---
+	ReflectionFunction_GetResultType :: proc(inFunc: ^FunctionReflection) -> ^TypeReflection ---
+	ReflectionFunction_FindModifier :: proc(inFunc: ^FunctionReflection, modifierID: SlangModifierID) -> ^Modifier ---
+	ReflectionFunction_GetUserAttributeCount :: proc(inFunc: ^FunctionReflection) -> u32 ---
+	ReflectionFunction_GetUserAttribute :: proc(inFunc: ^FunctionReflection, index: u32) -> ^Attribute ---
+	ReflectionFunction_FindUserAttributeByName :: proc(inFunc: ^FunctionReflection, session: ^IGlobalSession, name: cstring) -> ^Attribute ---
+	ReflectionFunction_GetParameterCount :: proc(inFunc: ^FunctionReflection) -> u32 ---
+	ReflectionFunction_GetParameter :: proc(inFunc: ^FunctionReflection, index: u32) -> ^VariableReflection ---
+	ReflectionFunction_GetGenericContainer :: proc(func: ^FunctionReflection) -> ^GenericReflection ---
+	ReflectionFunction_applySpecializations :: proc(func: ^FunctionReflection, generic: ^GenericReflection) -> ^FunctionReflection ---
+	ReflectionFunction_specializeWithArgTypes :: proc(func: ^FunctionReflection, argTypeCount: Int, argTypes: ^TypeReflection) -> ^FunctionReflection ---
+	ReflectionFunction_isOverloaded :: proc(func: ^FunctionReflection) -> bool ---
+	ReflectionFunction_getOverloadCount :: proc(func: ^FunctionReflection) -> u32 ---
+	ReflectionFunction_getOverload :: proc(func: ^FunctionReflection, index: u32) -> ^FunctionReflection ---
+	
+	Reflection_getTypeFromDecl :: proc(decl: ^DeclReflection) -> ^TypeReflection ---
+	ReflectionDecl_findModifier :: proc(decl: ^DeclReflection, modifierID: SlangModifierID) -> ^Modifier ---
+	ReflectionDecl_getChildrenCount :: proc(parentDecl: ^DeclReflection) -> u32 ---
+	ReflectionDecl_getChild :: proc(parentDecl: ^DeclReflection, index: u32) -> ^DeclReflection ---
+	ReflectionDecl_getName :: proc(decl: ^DeclReflection) -> cstring ---
+	ReflectionDecl_getKind :: proc(decl: ^DeclReflection) -> DeclKind ---
+	ReflectionDecl_castToFunction :: proc(decl: ^DeclReflection) -> ^FunctionReflection ---
+	ReflectionDecl_castToVariable :: proc(decl: ^DeclReflection) -> ^VariableReflection ---
+	ReflectionDecl_castToGeneric :: proc(decl: ^DeclReflection) -> ^GenericReflection ---
+	ReflectionDecl_getParent :: proc(decl: ^DeclReflection) -> ^DeclReflection ---
+
+	ReflectionGeneric_asDecl :: proc(generic: ^GenericReflection) -> ^DeclReflection ---
+	ReflectionGeneric_GetName :: proc(generic: ^GenericReflection) -> cstring ---
+	ReflectionGeneric_GetTypeParameterCount :: proc(generic: ^GenericReflection) -> u32 ---
+	ReflectionGeneric_GetTypeParameter :: proc(generic: ^GenericReflection, index: u32) -> ^VariableReflection ---
+	ReflectionGeneric_GetValueParameterCount :: proc(generic: ^GenericReflection) -> u32 ---
+	ReflectionGeneric_GetValueParameter :: proc(generic: ^GenericReflection, index: u32) -> ^VariableReflection ---
+	ReflectionGeneric_GetTypeParameterConstraintCount :: proc(generic: ^GenericReflection, typeParam: ^VariableReflection) -> u32 ---
+	ReflectionGeneric_GetTypeParameterConstraintType :: proc(generic: ^GenericReflection, typeParam: ^VariableReflection, index: u32) -> ^TypeReflection ---
+	ReflectionGeneric_GetInnerKind :: proc(generic: ^GenericReflection) -> DeclKind ---
+	ReflectionGeneric_GetInnerDecl :: proc(generic: ^GenericReflection) -> ^DeclReflection ---
+	ReflectionGeneric_GetOuterGenericContainer :: proc(generic: ^GenericReflection) -> ^GenericReflection ---
+	ReflectionGeneric_GetConcreteType :: proc(generic: ^GenericReflection, typeParam: ^VariableReflection) -> ^TypeReflection ---
+	ReflectionGeneric_GetConcreteIntVal :: proc(generic: ^GenericReflection, valueParam: ^VariableReflection) -> i64 ---
+	ReflectionGeneric_applySpecializations :: proc(currGeneric: ^GenericReflection, generic: ^GenericReflection) -> ^GenericReflection ---
+
+	ReflectionParameter_GetBindingIndex :: proc(inVarLayout: ^VariableLayoutReflection) -> u32 ---
+	ReflectionParameter_GetBindingSpace :: proc(inVarLayout: ^VariableLayoutReflection) -> u32 ---
+	@(deprecated="Use IMetadata->isParameterLocationUsed() instead.")
+	IsParameterLocationUsed :: proc(request: ^ICompileRequest,  entryPointIndex: Int, targetIndex: Int, category: ParameterCategory, spaceIndex: UInt, registerIndex: UInt, outUsed: ^bool) -> Result ---
+
+	ReflectionEntryPoint_getName :: proc(inEntryPoint: ^EntryPointReflection) -> cstring ---
+	ReflectionEntryPoint_getNameOverride :: proc(inEntryPoint: ^EntryPointReflection) -> cstring ---
+	ReflectionEntryPoint_getFunction :: proc(inEntryPoint: ^EntryPointReflection) -> ^FunctionReflection ---
+	ReflectionEntryPoint_getParameterCount :: proc(inEntryPoint: ^EntryPointReflection) -> u32 ---
+	ReflectionEntryPoint_getParameterByIndex :: proc(inEntryPoint: ^EntryPointReflection, index: u32) -> ^VariableLayoutReflection ---
+	ReflectionEntryPoint_getStage :: proc(inEntryPoint: ^EntryPointReflection) -> Stage ---
+	ReflectionEntryPoint_getComputeThreadGroupSize :: proc(inEntryPoint: ^EntryPointReflection, axisCount: UInt, outSizeAlongAxis: ^UInt) ---
+	ReflectionEntryPoint_getComputeWaveSize :: proc(inEntryPoint: ^EntryPointReflection, outWaveSize: ^UInt) ---
+	ReflectionEntryPoint_usesAnySampleRateInput :: proc(inEntryPoint: ^EntryPointReflection) -> int ---
+	ReflectionEntryPoint_getVarLayout :: proc(inEntryPoint: ^EntryPointReflection) -> ^VariableLayoutReflection ---
+	ReflectionEntryPoint_getResultVarLayout :: proc(inEntryPoint: ^EntryPointReflection) -> ^VariableLayoutReflection ---
+	ReflectionEntryPoint_hasDefaultConstantBuffer :: proc(inEntryPoint: ^EntryPointReflection) -> int ---
+
+	ReflectionTypeParameter_GetName :: proc(inTypeParam: ^TypeParameterReflection) -> cstring ---
+	ReflectionTypeParameter_GetIndex :: proc(inTypeParam: ^TypeParameterReflection) -> u32 ---
+	ReflectionTypeParameter_GetConstraintCount :: proc(inTypeParam: ^TypeParameterReflection) -> u32 ---
+	ReflectionTypeParameter_GetConstraintByIndex :: proc(inTypeParam: ^TypeParameterReflection, index: u32) -> ^TypeReflection ---
+
+	Reflection_GetParameterCount :: proc(inProgram: ^ProgramLayout) -> u32 ---
+	Reflection_GetParameterByIndex :: proc(inProgram: ^ProgramLayout, index: u32) -> ^VariableLayoutReflection ---
+	Reflection_getGlobalParamsVarLayout :: proc(inProgram: ^ProgramLayout) -> ^VariableLayoutReflection ---
+	Reflection_GetTypeParameterCount :: proc(reflection: ^ProgramLayout) -> u32 ---
+	Reflection_GetTypeParameterByIndex :: proc(reflection: ^ProgramLayout, index: u32) -> ^TypeParameterReflection ---
+	Reflection_FindTypeParameter :: proc(inProgram: ^ProgramLayout, name: cstring) -> ^TypeParameterReflection ---
+	Reflection_getEntryPointCount :: proc(inProgram: ^ProgramLayout) -> UInt ---
+	Reflection_getEntryPointByIndex :: proc(inProgram: ^ProgramLayout, index: UInt) -> ^EntryPointReflection ---
+	Reflection_findEntryPointByName :: proc(inProgram: ^ProgramLayout, name: cstring) -> ^EntryPointReflection ---
+	Reflection_getGlobalConstantBufferBinding :: proc(inProgram: ^ProgramLayout) -> UInt ---
+	Reflection_getGlobalConstantBufferSize :: proc(inProgram: ^ProgramLayout) -> uint ---
+	Reflection_specializeType :: proc(inProgramLayout: ^ProgramLayout, inType: ^TypeReflection, specializationArgCount: Int, specializationArgs: ^TypeReflection, outDiagnostics: ^^IBlob) -> ^TypeReflection ---
+	Reflection_specializeGeneric :: proc(inProgramLayout: ^ProgramLayout, generic: ^GenericReflection, argCount: Int, argTypes: ^GenericArgType, args: ^SlangReflectionGenericArg, outDiagnostics: ^^IBlob) -> ^GenericReflection ---
+	Reflection_getHashedStringCount :: proc(reflection: ^ProgramLayout) -> UInt ---
+	Reflection_getHashedString :: proc(reflection: ^ProgramLayout, index: UInt, outCount: ^uint) -> cstring ---
+
+	ComputeStringHash :: proc(chars: cstring, count: uint) -> u32 ---
+
+	Reflection_getGlobalParamsTypeLayout :: proc(reflection: ^ProgramLayout) -> ^TypeLayoutReflection ---
+	Reflection_ToJson :: proc(reflection: ^ProgramLayout,request: ^ICompileRequest, outBlob: ^^IBlob) -> Result ---
+}

--- a/slang/reflection_helper_methods.odin
+++ b/slang/reflection_helper_methods.odin
@@ -1,0 +1,194 @@
+package slang
+
+variable_getName                 :: proc(this: ^VariableReflection) -> cstring { return ReflectionVariable_GetName(this) }
+variable_getType                 :: proc(this: ^VariableReflection) -> ^TypeReflection { return (^TypeReflection)(ReflectionVariable_GetType(this)) }
+variable_findModifier            :: proc(this: ^VariableReflection, id: ModifierID) -> ^Modifier { return (^Modifier)(ReflectionVariable_FindModifier(this, (SlangModifierID)(id),)) }
+variable_getUserAttributeCount   :: proc(this: ^VariableReflection) -> u32 { return ReflectionVariable_GetUserAttributeCount(this) }
+variable_getUserAttributeByIndex :: proc(this: ^VariableReflection, index: u32) -> ^Attribute { return (^Attribute)(ReflectionVariable_GetUserAttribute(this, index,)) }
+variable_findAttributeByName     :: proc(this: ^VariableReflection, globalSession: ^IGlobalSession, name: cstring,) -> ^Attribute { return (^Attribute)(ReflectionVariable_FindUserAttributeByName(this, globalSession, name,)) }
+variable_getDefaultValueInt      :: proc(this: ^VariableReflection, value: ^i64) -> Result { return ReflectionVariable_GetDefaultValueInt(this, value) }
+
+type_getName               :: proc(this: ^TypeReflection) -> cstring { return ReflectionType_GetName(this) }
+type_getKind               :: proc(this: ^TypeReflection) -> TypeReflectionKind { return TypeReflectionKind(ReflectionType_GetKind(this)) }
+type_getScalarType         :: proc(this: ^TypeReflection) -> TypeReflectionScalarType { return cast(TypeReflectionScalarType)ReflectionType_GetScalarType(this) }
+type_getResourceResultType :: proc(this: ^TypeReflection) -> ^TypeReflection { return (^TypeReflection)(ReflectionType_GetResourceResultType(this)) }
+type_getResourceShape      :: proc(this: ^TypeReflection) -> SlangResourceShape { return ReflectionType_GetResourceShape(this) }
+type_getResourceAccess     :: proc(this: ^TypeReflection) -> SlangResourceAccess { return ReflectionType_GetResourceAccess(this) }
+type_getFieldCount         :: proc(this: ^TypeReflection) -> u32 { return ReflectionType_GetFieldCount(this) }
+type_getFieldByIndex       :: proc(this: ^TypeReflection, index: u32) -> ^VariableReflection { return (^VariableReflection)(ReflectionType_GetFieldByIndex(this, index)) }
+type_getElementCount       :: proc(this: ^TypeReflection, reflection: ^ProgramLayout = nil) -> uint { return ReflectionType_GetSpecializedElementCount(this, reflection) }
+type_getElementType        :: proc(this: ^TypeReflection) -> ^TypeReflection { return (^TypeReflection)(ReflectionType_GetElementType(this)) }
+type_getRowCount           :: proc(this: ^TypeReflection) -> u32 { return ReflectionType_GetRowCount(this) }
+type_getColumnCount        :: proc(this: ^TypeReflection) -> u32 { return ReflectionType_GetColumnCount(this) }
+type_isArray               :: proc(this: ^TypeReflection) -> bool { return type_getKind(this) == .Array }
+type_unwrapArray :: proc(this: ^TypeReflection) -> ^TypeReflection {
+	type := this
+	for type_isArray(type) {
+		type = type_getElementType(type)
+	}
+	return type
+}
+type_getTotalArrayElementCount :: proc(this: ^TypeReflection) -> uint {
+	if !type_isArray(this) { return 0 }
+	result := uint(1)
+	type := this
+	for {
+		if !type_isArray(type) { return result }
+		c := type_getElementCount(type)
+		if c == UNKNOWN_SIZE   { return UNKNOWN_SIZE   }
+		if c == UNBOUNDED_SIZE { return UNBOUNDED_SIZE }
+		result *= c
+		type = type_getElementType(type)
+	}
+}
+program_layout_getGlobalParamsVarLayout :: proc(this: ^ProgramLayout) -> ^VariableLayoutReflection { return (^VariableLayoutReflection)(Reflection_getGlobalParamsVarLayout(this)) }
+@(deprecated="https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/09-reflection.html#id2") 
+program_layout_getParameterCount        :: proc(this: ^ProgramLayout) -> u32 { return Reflection_GetParameterCount(this) }
+program_layout_getTypeParameterCount    :: proc(this: ^ProgramLayout) -> u32 { return Reflection_GetTypeParameterCount(this) }
+program_layout_findTypeParameter        :: proc(this: ^ProgramLayout, name: cstring) -> ^TypeParameterReflection { return Reflection_FindTypeParameter(this, name) }
+program_layout_getEntryPointCount       :: proc(this: ^ProgramLayout) -> UInt { return Reflection_getEntryPointCount(this) }
+program_layout_getEntryPointByIndex     :: proc(this: ^ProgramLayout, index: UInt) -> ^EntryPointReflection { return Reflection_getEntryPointByIndex(this, index) }
+program_layout_getGlobalConstantBufferBinding :: proc(this: ^ProgramLayout) -> UInt { return Reflection_getGlobalConstantBufferBinding(this) }
+program_layout_getGlobalConstantBufferSize    :: proc(this: ^ProgramLayout) -> uint { return Reflection_getGlobalConstantBufferSize(this) }
+program_layout_findTypeByName       :: proc(this: ^ProgramLayout, name: cstring) -> ^TypeReflection { return Reflection_FindTypeByName(this, name) }
+program_layout_findFunctionByName   :: proc(this: ^ProgramLayout, name: cstring) -> ^FunctionReflection { return Reflection_FindFunctionByName(this, name) }
+program_layout_findEntryPointByName :: proc(this: ^ProgramLayout, name: cstring) -> ^EntryPointReflection { return Reflection_findEntryPointByName(this, name) }
+program_layout_toJson               :: proc(this: ^ProgramLayout, outBlob: ^^IBlob) -> Result { return Reflection_ToJson(this, nil, outBlob) }
+
+variable_layout_getVariable        :: proc(this: ^VariableLayoutReflection) -> ^VariableReflection { return ReflectionVariableLayout_GetVariable(this) }
+variable_layout_getTypeLayout      :: proc(this: ^VariableLayoutReflection) -> ^TypeLayoutReflection { return ReflectionVariableLayout_GetTypeLayout(this) }
+variable_layout_getName            :: proc(this: ^VariableLayoutReflection) -> cstring { return variable_getName(variable_layout_getVariable(this)) }
+variable_layout_findModifier       :: proc(this: ^VariableLayoutReflection, id: ModifierID) -> ^Modifier { return variable_findModifier(variable_layout_getVariable(this), id) }
+variable_layout_getCategory        :: proc(this: ^VariableLayoutReflection) -> ParameterCategory { return type_layout_getParameterCategory(variable_layout_getTypeLayout(this)) }
+variable_layout_getCategoryCount   :: proc(this: ^VariableLayoutReflection) -> u32 { return type_layout_getCategoryCount(variable_layout_getTypeLayout(this)) }
+variable_layout_getCategoryByIndex :: proc(this: ^VariableLayoutReflection, index: u32) -> LayoutUnit { return type_layout_getCategoryByIndex(variable_layout_getTypeLayout(this), index) }
+variable_layout_getOffset          :: proc(this: ^VariableLayoutReflection, category: LayoutUnit) -> uint { return ReflectionVariableLayout_GetOffset(this, ParameterCategory(category)) }
+variable_layout_getBindingIndex    :: proc(this: ^VariableLayoutReflection) -> u32 { return ReflectionParameter_GetBindingIndex(this) }
+variable_layout_getType            :: proc(this: ^VariableLayoutReflection) -> ^TypeReflection { return variable_getType(variable_layout_getVariable(this) ) }
+
+variable_layout_getBindingSpace :: proc(this: ^VariableLayoutReflection, category: LayoutUnit) -> uint {
+	if category == .None {
+		return cast(uint)variable_layout_getBindingSpace_bytes(this),
+	} else {
+		return variable_layout_getBindingSpace_as_unit(this, category),
+	}
+}
+
+variable_layout_getBindingSpace_bytes   :: proc(this: ^VariableLayoutReflection) -> u32 { return ReflectionParameter_GetBindingSpace(this) }
+variable_layout_getBindingSpace_as_unit :: proc(this: ^VariableLayoutReflection, category: LayoutUnit) -> uint { return ReflectionVariableLayout_GetSpace(this, ParameterCategory(category)) }
+variable_layout_getImageFormat          :: proc(this: ^VariableLayoutReflection) -> ImageFormat { return ReflectionVariableLayout_GetImageFormat(this) }
+variable_layout_getSemanticName         :: proc(this: ^VariableLayoutReflection) -> cstring { return ReflectionVariableLayout_GetSemanticName(this) }
+variable_layout_getSemanticIndex        :: proc(this: ^VariableLayoutReflection) -> uint { return ReflectionVariableLayout_GetSemanticIndex(this) }
+variable_layout_getStage                :: proc(this: ^VariableLayoutReflection) -> Stage { return ReflectionVariableLayout_getStage(this) }
+
+function_getName                 :: proc(this: ^FunctionReflection) -> cstring { return ReflectionFunction_GetName(this) }
+function_getReturnType           :: proc(this: ^FunctionReflection) -> ^TypeReflection { return ReflectionFunction_GetResultType(this) }
+function_getParameterCount       :: proc(this: ^FunctionReflection) -> u32 { return ReflectionFunction_GetParameterCount(this) }
+function_getUserAttributeCount   :: proc(this: ^FunctionReflection) -> u32 { return ReflectionFunction_GetUserAttributeCount(this) }
+function_getUserAttributeByIndex :: proc(this: ^FunctionReflection, index: u32) -> ^Attribute { return ReflectionFunction_GetUserAttribute(this, index) }
+function_findAttributeByName     :: proc(this: ^FunctionReflection, globalSession: ^IGlobalSession, name: cstring) -> ^Attribute { return ReflectionFunction_FindUserAttributeByName(this, globalSession, name) }
+function_findUserAttributeByName :: proc(this: ^FunctionReflection, globalSession: ^IGlobalSession, name: cstring) -> ^Attribute{ return function_findAttributeByName(this, globalSession, name) }
+function_isOverloaded            :: proc(this: ^FunctionReflection) -> bool { return ReflectionFunction_isOverloaded(this) }
+function_getOverloadCount        :: proc(this: ^FunctionReflection) -> u32 { return ReflectionFunction_getOverloadCount(this) }
+function_findModifier            :: proc(this: ^FunctionReflection, id: ModifierID) -> ^Modifier { return ReflectionFunction_FindModifier((this), cast(SlangModifierID)id) }
+function_getGenericContainer     :: proc(this: ^FunctionReflection) -> ^GenericReflection { return ReflectionFunction_GetGenericContainer(this) }
+function_applySpecializations    :: proc(this: ^FunctionReflection, generic: ^GenericReflection) -> ^FunctionReflection { return ReflectionFunction_applySpecializations(this, generic) }
+function_specializeWithArgTypes  :: proc(this: ^FunctionReflection, argCount: u32, types: ^TypeReflection) -> ^FunctionReflection { return ReflectionFunction_specializeWithArgTypes(this, int(argCount), types) }
+function_getOverload             :: proc(this: ^FunctionReflection, index: u32) -> ^FunctionReflection { return ReflectionFunction_getOverload(this, index) }
+
+generic_asDecl                 :: proc(this: ^GenericReflection) -> ^DeclReflection { return ReflectionGeneric_asDecl(this) }
+generic_getName                :: proc(this: ^GenericReflection) -> cstring { return ReflectionGeneric_GetName(this) }
+generic_getTypeParameterCount  :: proc(this: ^GenericReflection) -> u32 { return ReflectionGeneric_GetTypeParameterCount(this) }
+generic_getValueParameterCount :: proc(this: ^GenericReflection) -> u32 { return ReflectionGeneric_GetValueParameterCount(this) }
+generic_getInnerDecl           :: proc(this: ^GenericReflection) -> ^DeclReflection { return ReflectionGeneric_GetInnerDecl(this) }
+generic_getInnerKind           :: proc(this: ^GenericReflection) -> DeclKind { return ReflectionGeneric_GetInnerKind(this) }
+
+entry_point_getName                   :: proc(this: ^EntryPointReflection) -> cstring { return ReflectionEntryPoint_getName(this) }
+entry_point_getNameOverride           :: proc(this: ^EntryPointReflection) -> cstring { return ReflectionEntryPoint_getNameOverride(this) }
+@(deprecated="https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/09-reflection.html#id3") 
+entry_point_getParameterCount         :: proc(this: ^EntryPointReflection) -> u32 { return ReflectionEntryPoint_getParameterCount(this) }
+entry_point_getStage                  :: proc(this: ^EntryPointReflection) -> Stage { return ReflectionEntryPoint_getStage(this) }
+entry_point_getFunction               :: proc(this: ^EntryPointReflection) -> ^FunctionReflection { return ReflectionEntryPoint_getFunction(this) }
+@(deprecated="https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/09-reflection.html#id3") 
+entry_point_getParameterByIndex       :: proc(this: ^EntryPointReflection, index: u32) -> ^VariableLayoutReflection { return ReflectionEntryPoint_getParameterByIndex(this, index) }
+entry_point_getComputeThreadGroupSize :: proc(this: ^EntryPointReflection, axisCount: UInt, outSizeAlongAxis: ^UInt) { ReflectionEntryPoint_getComputeThreadGroupSize(this, axisCount, outSizeAlongAxis) }
+entry_point_getComputeWaveSize        :: proc(this: ^EntryPointReflection, outWaveSize: ^UInt) { ReflectionEntryPoint_getComputeWaveSize(this, outWaveSize) }
+entry_point_usesAnySampleRateInput    :: proc(this: ^EntryPointReflection) -> bool { return 0 != ReflectionEntryPoint_usesAnySampleRateInput(this) }
+entry_point_getVarLayout              :: proc(this: ^EntryPointReflection) -> ^VariableLayoutReflection { return ReflectionEntryPoint_getVarLayout(this) }
+entry_point_getTypeLayout             :: proc(this: ^EntryPointReflection) -> ^TypeLayoutReflection { return variable_layout_getTypeLayout(entry_point_getVarLayout(this)) }
+entry_point_getResultVarLayout        :: proc(this: ^EntryPointReflection) -> ^VariableLayoutReflection { return ReflectionEntryPoint_getResultVarLayout(this) }
+entry_point_hasDefaultConstantBuffer  :: proc(this: ^EntryPointReflection) -> bool { return ReflectionEntryPoint_hasDefaultConstantBuffer(this) != 0 }
+
+type_layout_getType              :: proc(this: ^TypeLayoutReflection) -> ^TypeReflection { return ReflectionTypeLayout_GetType(this) }
+type_layout_getKind              :: proc(this: ^TypeLayoutReflection) -> TypeReflectionKind { return cast(TypeReflectionKind)ReflectionTypeLayout_getKind(this) }
+type_layout_getSize              :: proc(this: ^TypeLayoutReflection, category: LayoutUnit = .None) -> uint { return ReflectionTypeLayout_GetSize(this, ParameterCategory(category)) }
+type_layout_getStride            :: proc(this: ^TypeLayoutReflection, category: LayoutUnit = .None) -> uint { return ReflectionTypeLayout_GetStride(this, ParameterCategory(category)) }
+type_layout_getAlignment         :: proc(this: ^TypeLayoutReflection, category: LayoutUnit = .None) -> i32 { return ReflectionTypeLayout_getAlignment(this, ParameterCategory(category)) }
+type_layout_getFieldCount        :: proc(this: ^TypeLayoutReflection) -> u32 { return ReflectionTypeLayout_GetFieldCount(this) }
+type_layout_getFieldByIndex      :: proc(this: ^TypeLayoutReflection, index: u32) -> ^VariableLayoutReflection { return ReflectionTypeLayout_GetFieldByIndex(this, index) }
+type_layout_findFieldIndexByName :: proc(this: ^TypeLayoutReflection, nameBegin: cstring, nameEnd: cstring) -> Int { return ReflectionTypeLayout_findFieldIndexByName(this, nameBegin, nameEnd) }
+type_layout_getExplicitCounter   :: proc(this: ^TypeLayoutReflection) -> ^VariableLayoutReflection { return ReflectionTypeLayout_GetExplicitCounter(this) }
+type_layout_isArray              :: proc(this: ^TypeLayoutReflection) -> bool { return type_isArray(type_layout_getType(this)) }
+type_layout_unwrapArray :: proc(this: ^TypeLayoutReflection) -> ^TypeLayoutReflection {
+	type_layout := this
+	for type_layout_isArray(type_layout) {
+		type_layout = type_layout_getElementTypeLayout(type_layout)
+	}
+	return type_layout
+}
+type_layout_getTotalArrayElementCount   :: proc(this: ^TypeLayoutReflection) -> uint { return type_getTotalArrayElementCount(type_layout_getType(this)) }
+type_layout_getElementCount             :: proc(this: ^TypeLayoutReflection, reflection: ^ProgramLayout = nil) -> uint { return type_getElementCount(type_layout_getType(this), reflection) }
+type_layout_getElementStride            :: proc(this: ^TypeLayoutReflection, category: ParameterCategory) -> uint { return ReflectionTypeLayout_GetElementStride(this, category) }
+type_layout_getElementTypeLayout        :: proc(this: ^TypeLayoutReflection) -> ^TypeLayoutReflection { return ReflectionTypeLayout_GetElementTypeLayout(this) }
+type_layout_getElementVarLayout         :: proc(this: ^TypeLayoutReflection) -> ^VariableLayoutReflection { return ReflectionTypeLayout_GetElementVarLayout(this) }
+type_layout_getContainerVarLayout       :: proc(this: ^TypeLayoutReflection) -> ^VariableLayoutReflection { return ReflectionTypeLayout_getContainerVarLayout(this) }
+type_layout_getParameterCategory        :: proc(this: ^TypeLayoutReflection) -> ParameterCategory { return ReflectionTypeLayout_GetParameterCategory(this) }
+type_layout_getCategoryCount            :: proc(this: ^TypeLayoutReflection) -> u32 { return ReflectionTypeLayout_GetCategoryCount(this) }
+type_layout_getCategoryByIndex          :: proc(this: ^TypeLayoutReflection, index: u32) -> LayoutUnit { return ReflectionTypeLayout_GetCategoryByIndex(this, index) }
+type_layout_getRowCount                 :: proc(this: ^TypeLayoutReflection) -> u32 { return type_getRowCount(type_layout_getType(this)) }
+type_layout_getColumnCount              :: proc(this: ^TypeLayoutReflection) -> u32 { return type_getColumnCount(type_layout_getType(this)) }
+type_layout_getScalarType               :: proc(this: ^TypeLayoutReflection) -> TypeReflectionScalarType { return type_getScalarType(type_layout_getType(this)) }
+type_layout_getResourceResultType       :: proc(this: ^TypeLayoutReflection) -> ^TypeReflection { return type_getResourceResultType(type_layout_getType(this)) }
+type_layout_getResourceShape            :: proc(this: ^TypeLayoutReflection) -> SlangResourceShape { return type_getResourceShape(type_layout_getType(this)) }
+type_layout_getResourceAccess           :: proc(this: ^TypeLayoutReflection) -> SlangResourceAccess { return type_getResourceAccess(type_layout_getType(this)) }
+type_layout_getName                     :: proc(this: ^TypeLayoutReflection) -> cstring { return type_getName(type_layout_getType(this)) }
+type_layout_getMatrixLayoutMode         :: proc(this: ^TypeLayoutReflection) -> MatrixLayoutMode { return ReflectionTypeLayout_GetMatrixLayoutMode(this) }
+type_layout_getGenericParamIndex        :: proc(this: ^TypeLayoutReflection) -> i32 { return ReflectionTypeLayout_getGenericParamIndex(this) }
+type_layout_getBindingRangeCount        :: proc(this: ^TypeLayoutReflection) -> Int { return ReflectionTypeLayout_getBindingRangeCount(this) }
+type_layout_getBindingRangeType         :: proc(this: ^TypeLayoutReflection, index: Int) -> BindingType { return ReflectionTypeLayout_getBindingRangeType(this, index) }
+type_layout_isBindingRangeSpecializable :: proc(this: ^TypeLayoutReflection, index: Int) -> bool { return cast(bool)ReflectionTypeLayout_isBindingRangeSpecializable(this, index) }
+type_layout_getBindingRangeBindingCount                    :: proc(this: ^TypeLayoutReflection, index: Int) -> Int { return ReflectionTypeLayout_getBindingRangeBindingCount(this, index) }
+// @(deprecated="commented out in slang now")
+// type_layout_getBindingRangeIndexOffset                     :: proc(this: ^TypeLayoutReflection, index: Int) -> Int { return ReflectionTypeLayout_getBindingRangeIndexOffset(this, index) }
+// type_layout_getBindingRangeSpaceOffset                     :: proc(this: ^TypeLayoutReflection, index: Int) -> Int { return ReflectionTypeLayout_getBindingRangeSpaceOffset(this, index) }
+type_layout_getFieldBindingRangeOffset                     :: proc(this: ^TypeLayoutReflection, fieldIndex: Int) -> Int { return ReflectionTypeLayout_getFieldBindingRangeOffset(this, fieldIndex) }
+type_layout_getExplicitCounterBindingRangeOffset           :: proc(this: ^TypeLayoutReflection) -> Int { return ReflectionTypeLayout_getExplicitCounterBindingRangeOffset(this) }
+type_layout_getBindingRangeLeafTypeLayout                  :: proc(this: ^TypeLayoutReflection, index: Int) -> ^TypeLayoutReflection { return ReflectionTypeLayout_getBindingRangeLeafTypeLayout(this, index) }
+type_layout_getBindingRangeLeafVariable                    :: proc(this: ^TypeLayoutReflection, index: Int) -> ^VariableReflection { return ReflectionTypeLayout_getBindingRangeLeafVariable(this, index) }
+type_layout_getBindingRangeImageFormat                     :: proc(this: ^TypeLayoutReflection, index: Int) -> ImageFormat { return ReflectionTypeLayout_getBindingRangeImageFormat(this, index) }
+type_layout_getBindingRangeDescriptorSetIndex              :: proc(this: ^TypeLayoutReflection, index: Int) -> Int { return ReflectionTypeLayout_getBindingRangeDescriptorSetIndex(this, index) }
+type_layout_getBindingRangeFirstDescriptorRangeIndex       :: proc(this: ^TypeLayoutReflection, index: Int) -> Int { return ReflectionTypeLayout_getBindingRangeFirstDescriptorRangeIndex(this, index) }
+type_layout_getBindingRangeDescriptorRangeCount            :: proc(this: ^TypeLayoutReflection, index: Int) -> Int { return ReflectionTypeLayout_getBindingRangeDescriptorRangeCount(this, index) }
+type_layout_getDescriptorSetCount                          :: proc(this: ^TypeLayoutReflection) -> Int { return ReflectionTypeLayout_getDescriptorSetCount(this) }
+type_layout_getDescriptorSetSpaceOffset                    :: proc(this: ^TypeLayoutReflection, setIndex: Int) -> Int { return ReflectionTypeLayout_getDescriptorSetSpaceOffset(this, setIndex) }
+type_layout_getDescriptorSetDescriptorRangeCount           :: proc(this: ^TypeLayoutReflection, setIndex: Int) -> Int { return ReflectionTypeLayout_getDescriptorSetDescriptorRangeCount(this, setIndex) }
+type_layout_getDescriptorSetDescriptorRangeIndexOffset     :: proc(this: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> Int { return ReflectionTypeLayout_getDescriptorSetDescriptorRangeIndexOffset(this, setIndex, rangeIndex) }
+type_layout_getDescriptorSetDescriptorRangeDescriptorCount :: proc(this: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> Int { return ReflectionTypeLayout_getDescriptorSetDescriptorRangeDescriptorCount(this, setIndex, rangeIndex) }
+type_layout_getDescriptorSetDescriptorRangeType            :: proc(this: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> BindingType { return ReflectionTypeLayout_getDescriptorSetDescriptorRangeType(this, setIndex, rangeIndex) }
+type_layout_getDescriptorSetDescriptorRangeCategory        :: proc(this: ^TypeLayoutReflection, setIndex: Int, rangeIndex: Int) -> ParameterCategory { return ReflectionTypeLayout_getDescriptorSetDescriptorRangeCategory(this, setIndex, rangeIndex) }
+type_layout_getSubObjectRangeCount                         :: proc(this: ^TypeLayoutReflection) -> Int { return ReflectionTypeLayout_getSubObjectRangeCount(this) }
+type_layout_getSubObjectRangeBindingRangeIndex             :: proc(this: ^TypeLayoutReflection, subObjectRangeIndex: Int) -> Int { return ReflectionTypeLayout_getSubObjectRangeBindingRangeIndex(this, subObjectRangeIndex) }
+type_layout_getSubObjectRangeSpaceOffset                   :: proc(this: ^TypeLayoutReflection, subObjectRangeIndex: Int) -> Int { return ReflectionTypeLayout_getSubObjectRangeSpaceOffset(this, subObjectRangeIndex) }
+type_layout_getSubObjectRangeOffset                        :: proc(this: ^TypeLayoutReflection, subObjectRangeIndex: Int) -> ^VariableLayoutReflection { return ReflectionTypeLayout_getSubObjectRangeOffset(this, subObjectRangeIndex) }
+
+decl_getName          :: proc(this: ^DeclReflection) -> cstring { return ReflectionDecl_getName(this) }
+decl_getKind          :: proc(this: ^DeclReflection) -> DeclKind { return ReflectionDecl_getKind(this) }
+decl_getChildrenCount :: proc(this: ^DeclReflection) -> u32 { return ReflectionDecl_getChildrenCount(this) }
+decl_getChild         :: proc(this: ^DeclReflection, index: u32) -> ^DeclReflection { return ReflectionDecl_getChild(this, index) }
+decl_getType          :: proc(this: ^DeclReflection) -> ^TypeReflection { return Reflection_getTypeFromDecl(this) }
+decl_asVariable       :: proc(this: ^DeclReflection) -> ^VariableReflection { return ReflectionDecl_castToVariable(this) }
+decl_asFunction       :: proc(this: ^DeclReflection) -> ^FunctionReflection { return ReflectionDecl_castToFunction(this) }
+decl_asGeneric        :: proc(this: ^DeclReflection) -> ^GenericReflection { return ReflectionDecl_castToGeneric(this) }
+decl_getParent        :: proc(this: ^DeclReflection) -> ^DeclReflection { return ReflectionDecl_getParent(this) }
+decl_findModifier     :: proc(this: ^DeclReflection, id: ModifierID) -> ^Modifier { return ReflectionDecl_findModifier(this, cast(SlangModifierID)id) }
+// decl_getChildren // not really applicable to odin, maybe a custom iterator?

--- a/slang/reflection_wrapper/reflection_wrapper.odin
+++ b/slang/reflection_wrapper/reflection_wrapper.odin
@@ -1,0 +1,499 @@
+#+private
+package slang_reflection_wrapper
+
+import sp ".."
+
+// vtable globals
+@(rodata)
+g_VariableReflection_Vtable := VariableReflection_Vtable{
+	getName                 = sp.variable_getName,
+	getType                 = variable_getType,
+	findModifier            = sp.variable_findModifier,
+	getUserAttributeCount   = sp.variable_getUserAttributeCount,
+	getUserAttributeByIndex = sp.variable_getUserAttributeByIndex,
+	findAttributeByName     = sp.variable_findAttributeByName,
+	getDefaultValueInt      = sp.variable_getDefaultValueInt,
+}
+
+@(rodata)
+g_TypeReflection_Vtable := TypeReflection_Vtable{
+	getName                   = sp.type_getName,
+	getKind                   = sp.type_getKind,
+	getScalarType             = sp.type_getScalarType,
+	getResourceResultType     = type_getResourceResultType,
+	getResourceShape          = sp.type_getResourceShape,
+	getResourceAccess         = sp.type_getResourceAccess,
+	getFieldCount             = sp.type_getFieldCount,
+	getFieldByIndex           = type_getFieldByIndex,
+	getElementCount           = sp.type_getElementCount,
+	getElementType            = type_getElementType,
+	getRowCount               = sp.type_getRowCount,
+	getColumnCount            = sp.type_getColumnCount,
+	isArray                   = sp.type_isArray,
+	unwrapArray               = type_unwrapArray,
+	getTotalArrayElementCount = sp.type_getTotalArrayElementCount,
+}
+
+@(rodata)
+g_VariableLayoutReflection_Vtable := VariableLayoutReflection_Vtable{
+	getVariable        = variable_layout_getVariable,
+	getTypeLayout      = variable_layout_getTypeLayout,
+	getName            = sp.variable_layout_getName,
+	findModifier       = sp.variable_layout_findModifier,
+	getCategory        = sp.variable_layout_getCategory,
+	getCategoryCount   = sp.variable_layout_getCategoryCount,
+	getCategoryByIndex = sp.variable_layout_getCategoryByIndex,
+	getOffset          = sp.variable_layout_getOffset,
+	getBindingIndex    = sp.variable_layout_getBindingIndex,
+	getType            = variable_layout_getType,
+	getBindingSpace    = sp.variable_layout_getBindingSpace,
+	getImageFormat     = sp.variable_layout_getImageFormat,
+	getSemanticName    = sp.variable_layout_getSemanticName,
+	getSemanticIndex   = sp.variable_layout_getSemanticIndex,
+	getStage           = sp.variable_layout_getStage,
+}
+
+@(rodata)
+g_TypeLayoutReflection_Vtable := TypeLayoutReflection_Vtable{
+	getType                                        = type_layout_getType,
+	getKind                                        = sp.type_layout_getKind,
+	getSize                                        = sp.type_layout_getSize,
+	getStride                                      = sp.type_layout_getStride,
+	getAlignment                                   = sp.type_layout_getAlignment,
+	getFieldCount                                  = sp.type_layout_getFieldCount,
+	getFieldByIndex                                = type_layout_getFieldByIndex,
+	findFieldIndexByName                           = sp.type_layout_findFieldIndexByName,
+	getExplicitCounter                             = type_layout_getExplicitCounter,
+	isArray                                        = sp.type_layout_isArray,
+	unwrapArray                                    = type_layout_unwrapArray,
+	getTotalArrayElementCount                      = sp.type_layout_getTotalArrayElementCount,
+	getElementCount                                = sp.type_layout_getElementCount,
+	getElementStride                               = sp.type_layout_getElementStride,
+	getElementTypeLayout                           = type_layout_getElementTypeLayout,
+	getElementVarLayout                            = type_layout_getElementVarLayout,
+	getContainerVarLayout                          = type_layout_getContainerVarLayout,
+	getParameterCategory                           = sp.type_layout_getParameterCategory,
+	getCategoryCount                               = sp.type_layout_getCategoryCount,
+	getCategoryByIndex                             = sp.type_layout_getCategoryByIndex,
+	getRowCount                                    = sp.type_layout_getRowCount,
+	getColumnCount                                 = sp.type_layout_getColumnCount,
+	getScalarType                                  = sp.type_layout_getScalarType,
+	getResourceResultType                          = type_layout_getResourceResultType,
+	getResourceShape                               = sp.type_layout_getResourceShape,
+	getResourceAccess                              = sp.type_layout_getResourceAccess,
+	getName                                        = sp.type_layout_getName,
+	getMatrixLayoutMode                            = sp.type_layout_getMatrixLayoutMode,
+	getGenericParamIndex                           = sp.type_layout_getGenericParamIndex,
+	getBindingRangeCount                           = sp.type_layout_getBindingRangeCount,
+	getBindingRangeType                            = sp.type_layout_getBindingRangeType,
+	isBindingRangeSpecializable                    = sp.type_layout_isBindingRangeSpecializable,
+	getBindingRangeBindingCount                    = sp.type_layout_getBindingRangeBindingCount,
+	getFieldBindingRangeOffset                     = sp.type_layout_getFieldBindingRangeOffset,
+	getExplicitCounterBindingRangeOffset           = sp.type_layout_getExplicitCounterBindingRangeOffset,
+	getBindingRangeLeafTypeLayout                  = type_layout_getBindingRangeLeafTypeLayout,
+	getBindingRangeLeafVariable                    = type_layout_getBindingRangeLeafVariable,
+	getBindingRangeImageFormat                     = sp.type_layout_getBindingRangeImageFormat,
+	getBindingRangeDescriptorSetIndex              = sp.type_layout_getBindingRangeDescriptorSetIndex,
+	getBindingRangeFirstDescriptorRangeIndex       = sp.type_layout_getBindingRangeFirstDescriptorRangeIndex,
+	getBindingRangeDescriptorRangeCount            = sp.type_layout_getBindingRangeDescriptorRangeCount,
+	getDescriptorSetCount                          = sp.type_layout_getDescriptorSetCount,
+	getDescriptorSetSpaceOffset                    = sp.type_layout_getDescriptorSetSpaceOffset,
+	getDescriptorSetDescriptorRangeCount           = sp.type_layout_getDescriptorSetDescriptorRangeCount,
+	getDescriptorSetDescriptorRangeIndexOffset     = sp.type_layout_getDescriptorSetDescriptorRangeIndexOffset,
+	getDescriptorSetDescriptorRangeDescriptorCount = sp.type_layout_getDescriptorSetDescriptorRangeDescriptorCount,
+	getDescriptorSetDescriptorRangeType            = sp.type_layout_getDescriptorSetDescriptorRangeType,
+	getDescriptorSetDescriptorRangeCategory        = sp.type_layout_getDescriptorSetDescriptorRangeCategory,
+	getSubObjectRangeCount                         = sp.type_layout_getSubObjectRangeCount,
+	getSubObjectRangeBindingRangeIndex             = sp.type_layout_getSubObjectRangeBindingRangeIndex,
+	getSubObjectRangeSpaceOffset                   = sp.type_layout_getSubObjectRangeSpaceOffset,
+	getSubObjectRangeOffset                        = type_layout_getSubObjectRangeOffset,
+}
+
+@(rodata)
+g_EntryPointReflection_Vtable := EntryPointReflection_Vtable{
+	getName                   = sp.entry_point_getName,
+	getNameOverride           = sp.entry_point_getNameOverride,
+	getStage                  = sp.entry_point_getStage,
+	getFunction               = entry_point_getFunction,
+	getComputeThreadGroupSize = sp.entry_point_getComputeThreadGroupSize,
+	getComputeWaveSize        = sp.entry_point_getComputeWaveSize,
+	usesAnySampleRateInput    = sp.entry_point_usesAnySampleRateInput,
+	getVarLayout              = entry_point_getVarLayout,
+	getTypeLayout             = entry_point_getTypeLayout,
+	getResultVarLayout        = entry_point_getResultVarLayout,
+	hasDefaultConstantBuffer  = sp.entry_point_hasDefaultConstantBuffer,
+}
+
+@(rodata)
+g_ProgramLayout_Vtable := ProgramLayout_Vtable{
+	getGlobalParamsVarLayout       = program_layout_getGlobalParamsVarLayout,
+	getTypeParameterCount          = sp.program_layout_getTypeParameterCount,
+	findTypeParameter              = sp.program_layout_findTypeParameter,
+	getEntryPointCount             = sp.program_layout_getEntryPointCount,
+	getEntryPointByIndex           = program_layout_getEntryPointByIndex,
+	getGlobalConstantBufferBinding = sp.program_layout_getGlobalConstantBufferBinding,
+	getGlobalConstantBufferSize    = sp.program_layout_getGlobalConstantBufferSize,
+	findTypeByName                 = program_layout_findTypeByName,
+	findFunctionByName             = program_layout_findFunctionByName,
+	findEntryPointByName           = program_layout_findEntryPointByName,
+	toJson                         = sp.program_layout_toJson,
+}
+
+@(rodata)
+g_DeclReflection_Vtable := DeclReflection_Vtable{
+	getName          = sp.decl_getName,
+	getKind          = sp.decl_getKind,
+	getChildrenCount = sp.decl_getChildrenCount,
+	getChild         = decl_getChild,
+	getType          = decl_getType,
+	asVariable       = decl_asVariable,
+	asFunction       = decl_asFunction,
+	asGeneric        = decl_asGeneric,
+	getParent        = decl_getParent,
+	findModifier     = sp.decl_findModifier,
+}
+
+@(rodata)
+g_FunctionReflection_Vtable := FunctionReflection_Vtable{
+	getName                 = sp.function_getName,
+	getReturnType           = function_getReturnType,
+	getParameterCount       = sp.function_getParameterCount,
+	getUserAttributeCount   = sp.function_getUserAttributeCount,
+	getUserAttributeByIndex = sp.function_getUserAttributeByIndex,
+	findAttributeByName     = sp.function_findAttributeByName,
+	findUserAttributeByName = sp.function_findUserAttributeByName,
+	isOverloaded            = sp.function_isOverloaded,
+	getOverloadCount        = sp.function_getOverloadCount,
+	findModifier            = sp.function_findModifier,
+	getGenericContainer     = function_getGenericContainer,
+	applySpecializations    = function_applySpecializations,
+	specializeWithArgTypes  = function_specializeWithArgTypes,
+	getOverload             = function_getOverload,
+}
+
+@(rodata)
+g_GenericReflection_Vtable := GenericReflection_Vtable{
+	asDecl                 = generic_asDecl,
+	getName                = sp.generic_getName,
+	getTypeParameterCount  = sp.generic_getTypeParameterCount,
+	getValueParameterCount = sp.generic_getValueParameterCount,
+	getInnerDecl           = generic_getInnerDecl,
+	getInnerKind           = sp.generic_getInnerKind,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns variable
+
+type_getFieldByIndex :: proc(this: ^sp.TypeReflection, index: u32) -> VariableReflection {
+	variable: VariableReflection
+	variable.vtable   = &g_VariableReflection_Vtable
+	variable.variable = (^VariableReflection)(sp.ReflectionType_GetFieldByIndex(this, index)) 
+	return variable
+}
+
+variable_layout_getVariable :: proc(this: ^sp.VariableLayoutReflection) -> VariableReflection {
+	variable: VariableReflection
+	variable.vtable   = &g_VariableReflection_Vtable
+	variable.variable = sp.ReflectionVariableLayout_GetVariable(this)
+	return variable
+}
+
+type_layout_getBindingRangeLeafVariable :: proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> VariableReflection {
+	variable: VariableReflection
+	variable.vtable   = &g_VariableReflection_Vtable
+	variable.variable = sp.ReflectionTypeLayout_getBindingRangeLeafVariable(this, index)
+	return variable
+}
+
+decl_asVariable :: proc(this: ^sp.DeclReflection) -> VariableReflection {
+	variable: VariableReflection
+	variable.vtable   = &g_VariableReflection_Vtable
+	variable.variable = sp.ReflectionDecl_castToVariable(this) 
+	return variable
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns type
+
+variable_getType :: proc(this: ^sp.VariableReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.ReflectionVariable_GetType(this)
+	return type
+}
+
+type_getResourceResultType :: proc(this: ^sp.TypeReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.ReflectionType_GetResourceResultType(this)
+	return type
+	
+}
+
+type_getElementType :: proc(this: ^sp.TypeReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable  = &g_TypeReflection_Vtable
+	type.type    = sp.ReflectionType_GetElementType(this)
+	return type
+}
+
+type_unwrapArray :: proc(this: ^sp.TypeReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.type_unwrapArray(this)
+	return type
+}
+
+program_layout_findTypeByName :: proc(this: ^sp.ProgramLayout, name: cstring) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.Reflection_FindTypeByName(this, name)
+	return type
+}
+
+variable_layout_getType :: proc(this: ^sp.VariableLayoutReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.variable_getType(variable_layout_getVariable(this))
+	return type
+}
+
+function_getReturnType :: proc(this: ^sp.FunctionReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.ReflectionFunction_GetResultType(this)
+	return type
+}
+
+type_layout_getType :: proc(this: ^sp.TypeLayoutReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.ReflectionTypeLayout_GetType(this)
+	return type
+}
+
+type_layout_getResourceResultType :: proc(this: ^sp.TypeLayoutReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = type_getResourceResultType(type_layout_getType(this))
+	return type
+}
+
+decl_getType :: proc(this: ^sp.DeclReflection) -> TypeReflection {
+	type: TypeReflection
+	type.vtable = &g_TypeReflection_Vtable
+	type.type   = sp.Reflection_getTypeFromDecl(this)
+	return type
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns type layout
+
+variable_layout_getTypeLayout      :: proc(this: ^sp.VariableLayoutReflection) -> TypeLayoutReflection {
+	type_layout: TypeLayoutReflection
+	type_layout.vtable      = &g_TypeLayoutReflection_Vtable
+	type_layout.type_layout = sp.ReflectionVariableLayout_GetTypeLayout(this)
+	return type_layout
+}
+
+entry_point_getTypeLayout :: proc(this: ^sp.EntryPointReflection) -> TypeLayoutReflection {
+	type_layout: TypeLayoutReflection
+	type_layout.vtable      = &g_TypeLayoutReflection_Vtable
+	type_layout.type_layout = sp.variable_layout_getTypeLayout(sp.entry_point_getVarLayout(this))
+	return type_layout
+}
+
+type_layout_unwrapArray :: proc(this: ^sp.TypeLayoutReflection) -> TypeLayoutReflection {
+	type_layout: TypeLayoutReflection
+	type_layout.vtable      = &g_TypeLayoutReflection_Vtable
+	type_layout.type_layout = sp.type_layout_unwrapArray(this)
+	return type_layout
+
+}
+
+type_layout_getElementTypeLayout :: proc(this: ^sp.TypeLayoutReflection) -> TypeLayoutReflection {
+	type_layout: TypeLayoutReflection
+	type_layout.vtable      = &g_TypeLayoutReflection_Vtable
+	type_layout.type_layout = sp.ReflectionTypeLayout_GetElementTypeLayout(this)
+	return type_layout
+}
+
+type_layout_getBindingRangeLeafTypeLayout :: proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> TypeLayoutReflection {
+	type_layout: TypeLayoutReflection
+	type_layout.vtable      = &g_TypeLayoutReflection_Vtable
+	type_layout.type_layout = sp.ReflectionTypeLayout_getBindingRangeLeafTypeLayout(this, index)
+	return type_layout
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns variable layout
+
+program_layout_getGlobalParamsVarLayout :: proc(this: ^sp.ProgramLayout) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.Reflection_getGlobalParamsVarLayout(this)
+	return variable_layout
+}
+
+entry_point_getVarLayout :: proc(this: ^sp.EntryPointReflection) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionEntryPoint_getVarLayout(this)
+	return variable_layout
+}
+
+entry_point_getResultVarLayout :: proc(this: ^sp.EntryPointReflection) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionEntryPoint_getResultVarLayout(this)
+	return variable_layout
+}
+
+type_layout_getFieldByIndex :: proc(this: ^sp.TypeLayoutReflection, index: u32) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionTypeLayout_GetFieldByIndex(this, index)
+	return variable_layout
+}
+
+type_layout_getExplicitCounter :: proc(this: ^sp.TypeLayoutReflection) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionTypeLayout_GetExplicitCounter(this)
+	return variable_layout
+}
+
+type_layout_getElementVarLayout :: proc(this: ^sp.TypeLayoutReflection) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionTypeLayout_GetElementVarLayout(this)
+	return variable_layout
+}
+
+type_layout_getContainerVarLayout :: proc(this: ^sp.TypeLayoutReflection) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionTypeLayout_getContainerVarLayout(this)
+	return variable_layout
+
+}
+
+type_layout_getSubObjectRangeOffset :: proc(this: ^sp.TypeLayoutReflection, subObjectRangeIndex: sp.Int) -> VariableLayoutReflection {
+	variable_layout: VariableLayoutReflection
+	variable_layout.vtable          = &g_VariableLayoutReflection_Vtable
+	variable_layout.variable_layout = sp.ReflectionTypeLayout_getSubObjectRangeOffset(this, subObjectRangeIndex)
+	return variable_layout
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns entry point
+
+program_layout_getEntryPointByIndex :: proc(this: ^sp.ProgramLayout, index: sp.UInt) -> EntryPointReflection {
+	entry_point: EntryPointReflection
+	entry_point.vtable      = &g_EntryPointReflection_Vtable
+	entry_point.entry_point = sp.Reflection_getEntryPointByIndex(this, index)
+	return entry_point
+}
+
+program_layout_findEntryPointByName :: proc(this: ^sp.ProgramLayout, name: cstring) -> EntryPointReflection {
+	entry_point: EntryPointReflection
+	entry_point.vtable      = &g_EntryPointReflection_Vtable
+	entry_point.entry_point = sp.Reflection_findEntryPointByName(this, name)
+	return entry_point
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns decl
+
+generic_asDecl :: proc(this: ^sp.GenericReflection) -> DeclReflection {
+	decl: DeclReflection
+	decl.vtable = &g_DeclReflection_Vtable
+	decl.decl   = sp.ReflectionGeneric_asDecl(this)
+	return decl
+}
+
+generic_getInnerDecl :: proc(this: ^sp.GenericReflection) -> DeclReflection { 
+	decl: DeclReflection
+	decl.vtable = &g_DeclReflection_Vtable
+	decl.decl   = sp.ReflectionGeneric_GetInnerDecl(this)
+	return decl
+}
+
+decl_getChild :: proc(this: ^sp.DeclReflection, index: u32) -> DeclReflection {
+	decl: DeclReflection
+	decl.vtable = &g_DeclReflection_Vtable
+	decl.decl   = sp.ReflectionDecl_getChild(this, index)
+	return decl
+}
+
+decl_getParent :: proc(this: ^sp.DeclReflection) -> DeclReflection {
+	decl: DeclReflection
+	decl.vtable = &g_DeclReflection_Vtable
+	decl.decl   = sp.ReflectionDecl_getParent(this)
+	return decl
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns function
+
+program_layout_findFunctionByName   :: proc(this: ^sp.ProgramLayout, name: cstring) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = sp.Reflection_FindFunctionByName(this, name)
+	return function
+}
+
+function_applySpecializations :: proc(this: ^sp.FunctionReflection, generic: ^sp.GenericReflection) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = sp.ReflectionFunction_applySpecializations(this, generic)
+	return function
+ }
+
+function_specializeWithArgTypes :: proc(this: ^sp.FunctionReflection, argCount: u32, types: ^sp.TypeReflection) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = sp.ReflectionFunction_specializeWithArgTypes(this, int(argCount), types)
+	return function
+}
+
+function_getOverload :: proc(this: ^sp.FunctionReflection, index: u32) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = sp.ReflectionFunction_getOverload(this, index)
+	return function
+}
+
+entry_point_getFunction :: proc(this: ^sp.EntryPointReflection) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = sp.ReflectionEntryPoint_getFunction(this)
+	return function
+}
+
+decl_asFunction :: proc(this: ^sp.DeclReflection) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = sp.ReflectionDecl_castToFunction(this)
+	return function
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// returns generic
+
+function_getGenericContainer :: proc(this: ^sp.FunctionReflection) -> GenericReflection {
+	generic: GenericReflection
+	generic.vtable  = &g_GenericReflection_Vtable
+	generic.generic = sp.ReflectionFunction_GetGenericContainer(this)
+	return generic
+}
+
+decl_asGeneric :: proc(this: ^sp.DeclReflection) -> GenericReflection {
+	generic: GenericReflection
+	generic.vtable  = &g_GenericReflection_Vtable
+	generic.generic = sp.ReflectionDecl_castToGeneric(this)
+	return generic
+}

--- a/slang/reflection_wrapper/reflection_wrapper_public.odin
+++ b/slang/reflection_wrapper/reflection_wrapper_public.odin
@@ -1,0 +1,288 @@
+package slang_reflection_wrapper
+
+import sp ".."
+
+// The purpose of this package is an attempt at forward compatibility
+// with the slang COM api. 
+// It wraps the new helper methods (which have replaced the C api
+// but haven't made it into the COM api yet) into vtables.
+// With that, the usage is identical to the COM parts of the api and
+// when the C api reflection procs get removed it should be possible to
+// switch to their new counterparts with minimal changes to user code.
+
+// Usage:
+/*
+	There is a couple of awkward "boundaries" where the existing COM api and reflection overlap
+	namely the following 3 functions in slang.odin:
+	
+	getLayout:             proc "system"(this: ^IComponentType, targetIndex: Int, outDiagnostics: ^^IBlob) -> ^ProgramLayout,
+	getModuleReflection:   proc "system"(this: ^IModule) -> ^DeclReflection,
+	getFunctionReflection: proc "system"(this: ^IEntryPoint) -> ^FunctionReflection,
+	
+	we need to wrap these in the init proc, for example:
+	Example:
+		import refl "slang/reflection_wrapper"
+
+		program_layout := program->getLayout(target_index, &diags)
+
+		refl_program_layout := refl.init_program_layout(program_layout)
+		
+		// now everything we get through this wrapped program layout will have the correct methods
+		refl_program_layout->getGlobalParamsVarLayout()
+		entry_point_count := refl_program_layout->getEntryPointCount()
+			
+		for i in 0..<entry_point_count {
+			entry_point := refl_program_layout->getEntryPointByIndex(i)
+
+			scope_layout := entry_point->getVarLayout()
+
+			result_variable_layout := entry_point->getResultVarLayout()
+
+			result_type_layout := result_variable_layout->getTypeLayout()
+	
+	and so on..
+
+*/
+
+// Wrapper entry points
+init_program_layout :: proc(this: ^sp.ProgramLayout) -> ProgramLayout {
+	program_layout: ProgramLayout
+	program_layout.vtable         = &g_ProgramLayout_Vtable
+	program_layout.program_layout = this
+	return program_layout
+}
+
+init_decl :: proc(this: ^sp.DeclReflection) -> DeclReflection {
+	decl: DeclReflection
+	decl.vtable = &g_DeclReflection_Vtable
+	decl.decl   = this
+	return decl
+}
+
+init_function :: proc(this: ^sp.FunctionReflection) -> FunctionReflection {
+	function: FunctionReflection
+	function.vtable   = &g_FunctionReflection_Vtable
+	function.function = this
+	return function
+}
+
+// Wrapper types store the original pointer and add the vtable of helper methods
+VariableReflection :: struct {
+	using vtable:   ^VariableReflection_Vtable,
+	using variable: ^sp.VariableReflection,
+}
+
+TypeReflection :: struct {
+	using vtable: ^TypeReflection_Vtable,
+	using type:   ^sp.TypeReflection,
+}
+
+VariableLayoutReflection :: struct {
+	using vtable:          ^VariableLayoutReflection_Vtable,
+	using variable_layout: ^sp.VariableLayoutReflection,
+}
+
+TypeLayoutReflection :: struct {
+	using vtable:      ^TypeLayoutReflection_Vtable,
+	using type_layout: ^sp.TypeLayoutReflection,
+}
+
+EntryPointReflection :: struct {
+	using vtable:      ^EntryPointReflection_Vtable,
+	using entry_point: ^sp.EntryPointReflection,
+}
+
+ProgramLayout :: struct {
+	using vtable:         ^ProgramLayout_Vtable,
+	using program_layout: ^sp.ProgramLayout,
+}
+
+DeclReflection :: struct {
+	using vtable: ^DeclReflection_Vtable,
+	using decl:   ^sp.DeclReflection,
+}
+
+FunctionReflection :: struct {
+	using vtable:   ^FunctionReflection_Vtable,
+	using function: ^sp.FunctionReflection
+}
+
+GenericReflection :: struct {
+	using vtable:  ^GenericReflection_Vtable,
+	using generic: ^sp.GenericReflection
+}
+
+VariableReflection_Vtable :: struct {
+	getName                 : proc(this: ^sp.VariableReflection) -> cstring,
+	getType                 : proc(this: ^sp.VariableReflection) -> TypeReflection,
+	findModifier            : proc(this: ^sp.VariableReflection, id: sp.ModifierID) -> ^sp.Modifier,
+	getUserAttributeCount   : proc(this: ^sp.VariableReflection) -> u32,
+	getUserAttributeByIndex : proc(this: ^sp.VariableReflection, index: u32) -> ^sp.Attribute,
+	findAttributeByName     : proc(this: ^sp.VariableReflection, globalSession: ^sp.IGlobalSession, name: cstring,) -> ^sp.Attribute,
+	getDefaultValueInt      : proc(this: ^sp.VariableReflection, value: ^i64) -> sp.Result,
+
+}
+
+TypeReflection_Vtable :: struct {
+	getName               : proc(this: ^sp.TypeReflection) -> cstring,
+	getKind               : proc(this: ^sp.TypeReflection) -> sp.TypeReflectionKind,
+	getScalarType         : proc(this: ^sp.TypeReflection) -> sp.TypeReflectionScalarType,
+	getResourceResultType : proc(this: ^sp.TypeReflection) -> TypeReflection,
+	getResourceShape      : proc(this: ^sp.TypeReflection) -> sp.SlangResourceShape,
+	getResourceAccess     : proc(this: ^sp.TypeReflection) -> sp.SlangResourceAccess,
+	getFieldCount         : proc(this: ^sp.TypeReflection) -> u32,
+	getFieldByIndex       : proc(this: ^sp.TypeReflection, index: u32) -> VariableReflection,
+	getElementCount       : proc(this: ^sp.TypeReflection, reflection: ^sp.ProgramLayout = nil) -> uint,
+	getElementType        : proc(this: ^sp.TypeReflection) -> TypeReflection,
+	getRowCount           : proc(this: ^sp.TypeReflection) -> u32,
+	getColumnCount        : proc(this: ^sp.TypeReflection) -> u32,
+	isArray               : proc(this: ^sp.TypeReflection) -> bool,
+	unwrapArray               : proc(this: ^sp.TypeReflection) -> TypeReflection,
+	getTotalArrayElementCount : proc(this: ^sp.TypeReflection) -> uint,
+}
+
+
+TypeLayoutReflection_Vtable :: struct {
+	getType              : proc(this: ^sp.TypeLayoutReflection) -> TypeReflection,
+	getKind              : proc(this: ^sp.TypeLayoutReflection) -> sp.TypeReflectionKind,
+	getSize              : proc(this: ^sp.TypeLayoutReflection, category: sp.LayoutUnit) -> uint,
+	getStride            : proc(this: ^sp.TypeLayoutReflection, category: sp.LayoutUnit) -> uint,
+	getAlignment         : proc(this: ^sp.TypeLayoutReflection, category: sp.LayoutUnit) -> i32,
+	getFieldCount        : proc(this: ^sp.TypeLayoutReflection) -> u32,
+	getFieldByIndex      : proc(this: ^sp.TypeLayoutReflection, index: u32) -> VariableLayoutReflection,
+	findFieldIndexByName : proc(this: ^sp.TypeLayoutReflection, nameBegin: cstring, nameEnd: cstring) -> sp.Int,
+	getExplicitCounter   : proc(this: ^sp.TypeLayoutReflection) -> VariableLayoutReflection,
+	isArray              : proc(this: ^sp.TypeLayoutReflection) -> bool,
+	unwrapArray          : proc(this: ^sp.TypeLayoutReflection) -> TypeLayoutReflection,
+	getTotalArrayElementCount   : proc(this: ^sp.TypeLayoutReflection) -> uint,
+	getElementCount             : proc(this: ^sp.TypeLayoutReflection, reflection: ^sp.ProgramLayout) -> uint,
+	getElementStride            : proc(this: ^sp.TypeLayoutReflection, category: sp.ParameterCategory) -> uint,
+	getElementTypeLayout        : proc(this: ^sp.TypeLayoutReflection) -> TypeLayoutReflection,
+	getElementVarLayout         : proc(this: ^sp.TypeLayoutReflection) -> VariableLayoutReflection,
+	getContainerVarLayout       : proc(this: ^sp.TypeLayoutReflection) -> VariableLayoutReflection,
+	getParameterCategory        : proc(this: ^sp.TypeLayoutReflection) -> sp.LayoutUnit,
+	getCategoryCount            : proc(this: ^sp.TypeLayoutReflection) -> u32,
+	getCategoryByIndex          : proc(this: ^sp.TypeLayoutReflection, index: u32) -> sp.LayoutUnit,
+	getRowCount                 : proc(this: ^sp.TypeLayoutReflection) -> u32,
+	getColumnCount              : proc(this: ^sp.TypeLayoutReflection) -> u32,
+	getScalarType               : proc(this: ^sp.TypeLayoutReflection) -> sp.TypeReflectionScalarType,
+	getResourceResultType       : proc(this: ^sp.TypeLayoutReflection) -> TypeReflection,
+	getResourceShape            : proc(this: ^sp.TypeLayoutReflection) -> sp.SlangResourceShape,
+	getResourceAccess           : proc(this: ^sp.TypeLayoutReflection) -> sp.SlangResourceAccess,
+	getName                     : proc(this: ^sp.TypeLayoutReflection) -> cstring,
+	getMatrixLayoutMode         : proc(this: ^sp.TypeLayoutReflection) -> sp.MatrixLayoutMode,
+	getGenericParamIndex        : proc(this: ^sp.TypeLayoutReflection) -> i32,
+	getBindingRangeCount        : proc(this: ^sp.TypeLayoutReflection) -> sp.Int,
+	getBindingRangeType         : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> sp.BindingType,
+	isBindingRangeSpecializable : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> bool,
+	getBindingRangeBindingCount                    : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> sp.Int,
+	getFieldBindingRangeOffset                     : proc(this: ^sp.TypeLayoutReflection, fieldIndex: sp.Int) -> sp.Int,
+	getExplicitCounterBindingRangeOffset           : proc(this: ^sp.TypeLayoutReflection) -> sp.Int,
+	getBindingRangeLeafTypeLayout                  : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> TypeLayoutReflection,
+	getBindingRangeLeafVariable                    : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> VariableReflection,
+	getBindingRangeImageFormat                     : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> sp.ImageFormat,
+	getBindingRangeDescriptorSetIndex              : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> sp.Int,
+	getBindingRangeFirstDescriptorRangeIndex       : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> sp.Int,
+	getBindingRangeDescriptorRangeCount            : proc(this: ^sp.TypeLayoutReflection, index: sp.Int) -> sp.Int,
+	getDescriptorSetCount                          : proc(this: ^sp.TypeLayoutReflection) -> sp.Int,
+	getDescriptorSetSpaceOffset                    : proc(this: ^sp.TypeLayoutReflection, setIndex: sp.Int) -> sp.Int,
+	getDescriptorSetDescriptorRangeCount           : proc(this: ^sp.TypeLayoutReflection, setIndex: sp.Int) -> sp.Int,
+	getDescriptorSetDescriptorRangeIndexOffset     : proc(this: ^sp.TypeLayoutReflection, setIndex: sp.Int, rangeIndex: sp.Int) -> sp.Int,
+	getDescriptorSetDescriptorRangeDescriptorCount : proc(this: ^sp.TypeLayoutReflection, setIndex: sp.Int, rangeIndex: sp.Int) -> sp.Int,
+	getDescriptorSetDescriptorRangeType            : proc(this: ^sp.TypeLayoutReflection, setIndex: sp.Int, rangeIndex: sp.Int) -> sp.BindingType,
+	getDescriptorSetDescriptorRangeCategory        : proc(this: ^sp.TypeLayoutReflection, setIndex: sp.Int, rangeIndex: sp.Int) -> sp.ParameterCategory,
+	getSubObjectRangeCount                         : proc(this: ^sp.TypeLayoutReflection) -> sp.Int,
+	getSubObjectRangeBindingRangeIndex             : proc(this: ^sp.TypeLayoutReflection, subObjectRangeIndex: sp.Int) -> sp.Int,
+	getSubObjectRangeSpaceOffset                   : proc(this: ^sp.TypeLayoutReflection, subObjectRangeIndex: sp.Int) -> sp.Int,
+	getSubObjectRangeOffset                        : proc(this: ^sp.TypeLayoutReflection, subObjectRangeIndex: sp.Int) -> VariableLayoutReflection,
+}
+
+
+VariableLayoutReflection_Vtable :: struct {
+	getVariable             : proc(this: ^sp.VariableLayoutReflection) -> VariableReflection,
+	getTypeLayout           : proc(this: ^sp.VariableLayoutReflection) -> TypeLayoutReflection,
+	getName                 : proc(this: ^sp.VariableLayoutReflection) -> cstring,
+	findModifier            : proc(this: ^sp.VariableLayoutReflection, id: sp.ModifierID) -> ^sp.Modifier,
+	getCategory             : proc(this: ^sp.VariableLayoutReflection) -> sp.LayoutUnit,
+	getCategoryCount        : proc(this: ^sp.VariableLayoutReflection) -> u32,
+	getCategoryByIndex      : proc(this: ^sp.VariableLayoutReflection, index: u32) -> sp.LayoutUnit,
+	getOffset               : proc(this: ^sp.VariableLayoutReflection, category: sp.LayoutUnit) -> uint,
+	getBindingIndex         : proc(this: ^sp.VariableLayoutReflection) -> u32,
+	getType                 : proc(this: ^sp.VariableLayoutReflection) -> TypeReflection,
+	getBindingSpace         : proc(this: ^sp.VariableLayoutReflection, category: sp.LayoutUnit) -> uint,
+	getImageFormat          : proc(this: ^sp.VariableLayoutReflection) -> sp.ImageFormat,
+	getSemanticName         : proc(this: ^sp.VariableLayoutReflection) -> cstring,
+	getSemanticIndex        : proc(this: ^sp.VariableLayoutReflection) -> uint,
+	getStage                : proc(this: ^sp.VariableLayoutReflection) -> sp.Stage,
+}
+
+
+EntryPointReflection_Vtable :: struct {
+	getName                   : proc(this: ^sp.EntryPointReflection) -> cstring,
+	getNameOverride           : proc(this: ^sp.EntryPointReflection) -> cstring,
+	getStage                  : proc(this: ^sp.EntryPointReflection) -> sp.Stage,
+	getFunction               : proc(this: ^sp.EntryPointReflection) -> FunctionReflection,
+	getComputeThreadGroupSize : proc(this: ^sp.EntryPointReflection, axisCount: sp.UInt, outSizeAlongAxis: ^sp.UInt),
+	getComputeWaveSize        : proc(this: ^sp.EntryPointReflection, outWaveSize: ^sp.UInt),
+	usesAnySampleRateInput    : proc(this: ^sp.EntryPointReflection) -> bool,
+	getVarLayout              : proc(this: ^sp.EntryPointReflection) -> VariableLayoutReflection,
+	getTypeLayout             : proc(this: ^sp.EntryPointReflection) -> TypeLayoutReflection,
+	getResultVarLayout        : proc(this: ^sp.EntryPointReflection) -> VariableLayoutReflection,
+	hasDefaultConstantBuffer  : proc(this: ^sp.EntryPointReflection) -> bool,
+}
+
+
+ProgramLayout_Vtable :: struct {
+	getGlobalParamsVarLayout       : proc(this: ^sp.ProgramLayout) -> VariableLayoutReflection,
+	getTypeParameterCount          : proc(this: ^sp.ProgramLayout) -> u32,
+	findTypeParameter              : proc(this: ^sp.ProgramLayout, name: cstring) -> ^sp.TypeParameterReflection,
+	getEntryPointCount             : proc(this: ^sp.ProgramLayout) -> sp.UInt,
+	getEntryPointByIndex           : proc(this: ^sp.ProgramLayout, index: sp.UInt) -> EntryPointReflection,
+	getGlobalConstantBufferBinding : proc(this: ^sp.ProgramLayout) -> sp.UInt,
+	getGlobalConstantBufferSize    : proc(this: ^sp.ProgramLayout) -> uint,
+	findTypeByName                 : proc(this: ^sp.ProgramLayout, name: cstring) -> TypeReflection,
+	findFunctionByName             : proc(this: ^sp.ProgramLayout, name: cstring) -> FunctionReflection,
+	findEntryPointByName           : proc(this: ^sp.ProgramLayout, name: cstring) -> EntryPointReflection,
+	toJson                         : proc(this: ^sp.ProgramLayout, outBlob: ^^sp.IBlob) -> sp.Result,
+}
+
+
+DeclReflection_Vtable :: struct {
+	getName          : proc(this: ^sp.DeclReflection) -> cstring,
+	getKind          : proc(this: ^sp.DeclReflection) -> sp.DeclKind,
+	getChildrenCount : proc(this: ^sp.DeclReflection) -> u32,
+	getChild         : proc(this: ^sp.DeclReflection, index: u32) -> DeclReflection,
+	getType          : proc(this: ^sp.DeclReflection) -> TypeReflection,
+	asVariable       : proc(this: ^sp.DeclReflection) -> VariableReflection,
+	asFunction       : proc(this: ^sp.DeclReflection) -> FunctionReflection,
+	asGeneric        : proc(this: ^sp.DeclReflection) -> GenericReflection,
+	getParent        : proc(this: ^sp.DeclReflection) -> DeclReflection,
+	findModifier     : proc(this: ^sp.DeclReflection, id: sp.ModifierID) -> ^sp.Modifier,
+}
+
+
+FunctionReflection_Vtable :: struct {
+	getName                 : proc(this: ^sp.FunctionReflection) -> cstring,
+	getReturnType           : proc(this: ^sp.FunctionReflection) -> TypeReflection,
+	getParameterCount       : proc(this: ^sp.FunctionReflection) -> u32,
+	getUserAttributeCount   : proc(this: ^sp.FunctionReflection) -> u32,
+	getUserAttributeByIndex : proc(this: ^sp.FunctionReflection, index: u32) -> ^sp.Attribute,
+	findAttributeByName     : proc(this: ^sp.FunctionReflection, globalSession: ^sp.IGlobalSession, name: cstring) -> ^sp.Attribute,
+	findUserAttributeByName : proc(this: ^sp.FunctionReflection, globalSession: ^sp.IGlobalSession, name: cstring) -> ^sp.Attribute,
+	isOverloaded            : proc(this: ^sp.FunctionReflection) -> bool,
+	getOverloadCount        : proc(this: ^sp.FunctionReflection) -> u32,
+	findModifier            : proc(this: ^sp.FunctionReflection, id: sp.ModifierID) -> ^sp.Modifier,
+	getGenericContainer     : proc(this: ^sp.FunctionReflection) -> GenericReflection,
+	applySpecializations    : proc(this: ^sp.FunctionReflection, generic: ^sp.GenericReflection) -> FunctionReflection,
+	specializeWithArgTypes  : proc(this: ^sp.FunctionReflection, argCount: u32, types: ^sp.TypeReflection) -> FunctionReflection,
+	getOverload             : proc(this: ^sp.FunctionReflection, index: u32) -> FunctionReflection,
+}
+
+GenericReflection_Vtable :: struct {
+	asDecl                 : proc(this: ^sp.GenericReflection) -> DeclReflection,
+	getName                : proc(this: ^sp.GenericReflection) -> cstring,
+	getTypeParameterCount  : proc(this: ^sp.GenericReflection) -> u32,
+	getValueParameterCount : proc(this: ^sp.GenericReflection) -> u32,
+	getInnerDecl           : proc(this: ^sp.GenericReflection) -> DeclReflection,
+	getInnerKind           : proc(this: ^sp.GenericReflection) -> sp.DeclKind,
+}

--- a/slang/slang.odin
+++ b/slang/slang.odin
@@ -213,178 +213,181 @@ EmitSpirvMethod :: enum i32 {
 }
 
 CompilerOptionName :: enum i32 {
-    MacroDefine, // stringValue0: macro name;  stringValue1: macro value
-    DepFile,
-    EntryPointName,
-    Specialize,
-    Help,
-    HelpStyle,
-    Include, // stringValue: additional include path.
-    Language,
-    MatrixLayoutColumn,         // bool
-    MatrixLayoutRow,            // bool
-    ZeroInitialize,             // bool
-    IgnoreCapabilities,         // bool
-    RestrictiveCapabilityCheck, // bool
-    ModuleName,                 // stringValue0: module name.
-    Output,
-    Profile, // intValue0: profile
-    Stage,   // intValue0: stage
-    Target,  // intValue0: CodeGenTarget
-    Version,
-    WarningsAsErrors, // stringValue0: "all" or comma separated list of warning codes or names.
-    DisableWarnings,  // stringValue0: comma separated list of warning codes or names.
-    EnableWarning,    // stringValue0: warning code or name.
-    DisableWarning,   // stringValue0: warning code or name.
-    DumpWarningDiagnostics,
-    InputFilesRemain,
-    EmitIr,                        // bool
-    ReportDownstreamTime,          // bool
-    ReportPerfBenchmark,           // bool
-    ReportCheckpointIntermediates, // bool
-    SkipSPIRVValidation,           // bool
-    SourceEmbedStyle,
-    SourceEmbedName,
-    SourceEmbedLanguage,
-    DisableShortCircuit,            // bool
-    MinimumSlangOptimization,       // bool
-    DisableNonEssentialValidations, // bool
-    DisableSourceMap,               // bool
-    UnscopedEnum,                   // bool
-    PreserveParameters, // bool: preserve all resource parameters in the output code.
-    // Target
+	MacroDefine, // stringValue0: macro name;  stringValue1: macro value
+	DepFile,
+	EntryPointName,
+	Specialize,
+	Help,
+	HelpStyle,
+	Include, // stringValue: additional include path.
+	Language,
+	MatrixLayoutColumn,         // bool
+	MatrixLayoutRow,            // bool
+	ZeroInitialize,             // bool
+	IgnoreCapabilities,         // bool
+	RestrictiveCapabilityCheck, // bool
+	ModuleName,                 // stringValue0: module name.
+	Output,
+	Profile, // intValue0: profile
+	Stage,   // intValue0: stage
+	Target,  // intValue0: CodeGenTarget
+	Version,
+	WarningsAsErrors, // stringValue0: "all" or comma separated list of warning codes or names.
+	DisableWarnings,  // stringValue0: comma separated list of warning codes or names.
+	EnableWarning,    // stringValue0: warning code or name.
+	DisableWarning,   // stringValue0: warning code or name.
+	DumpWarningDiagnostics,
+	InputFilesRemain,
+	EmitIr,                        // bool
+	ReportDownstreamTime,          // bool
+	ReportPerfBenchmark,           // bool
+	ReportCheckpointIntermediates, // bool
+	SkipSPIRVValidation,           // bool
+	SourceEmbedStyle,
+	SourceEmbedName,
+	SourceEmbedLanguage,
+	DisableShortCircuit,            // bool
+	MinimumSlangOptimization,       // bool
+	DisableNonEssentialValidations, // bool
+	DisableSourceMap,               // bool
+	UnscopedEnum,                   // bool
+	PreserveParameters, // bool: preserve all resource parameters in the output code.
+	// Target
 
-    Capability,                // intValue0: CapabilityName
-    DefaultImageFormatUnknown, // bool
-    DisableDynamicDispatch,    // bool
-    DisableSpecialization,     // bool
-    FloatingPointMode,         // intValue0: FloatingPointMode
-    DebugInformation,          // intValue0: DebugInfoLevel
-    LineDirectiveMode,
-    Optimization, // intValue0: OptimizationLevel
-    Obfuscate,    // bool
+	Capability,                // intValue0: CapabilityName
+	// @NOTE(Xaryen): ^might be an error since aforementioned enum doesn't exist
+	// and e.g. https://docs.shader-slang.org/en/latest/external/slang/docs/user-guide/a2-01-spirv-target-specific.html
+	// uses stringValue0 instead to set vk_mem_model
+	DefaultImageFormatUnknown, // bool
+	DisableDynamicDispatch,    // bool
+	DisableSpecialization,     // bool
+	FloatingPointMode,         // intValue0: FloatingPointMode
+	DebugInformation,          // intValue0: DebugInfoLevel
+	LineDirectiveMode,
+	Optimization, // intValue0: OptimizationLevel
+	Obfuscate,    // bool
 
-    VulkanBindShift, // intValue0 (higher 8 bits): kind; intValue0(lower bits): set; intValue1:
-                     // shift
-    VulkanBindGlobals,       // intValue0: index; intValue1: set
-    VulkanInvertY,           // bool
-    VulkanUseDxPositionW,    // bool
-    VulkanUseEntryPointName, // bool
-    VulkanUseGLLayout,       // bool
-    VulkanEmitReflection,    // bool
+	VulkanBindShift, // intValue0 (higher 8 bits): kind; intValue0(lower bits): set; intValue1:
+					 // shift
+	VulkanBindGlobals,       // intValue0: index; intValue1: set
+	VulkanInvertY,           // bool
+	VulkanUseDxPositionW,    // bool
+	VulkanUseEntryPointName, // bool
+	VulkanUseGLLayout,       // bool
+	VulkanEmitReflection,    // bool
 
-    GLSLForceScalarLayout,   // bool
-    EnableEffectAnnotations, // bool
+	GLSLForceScalarLayout,   // bool
+	EnableEffectAnnotations, // bool
 
-    EmitSpirvViaGLSL,     // bool (will be deprecated)
-    EmitSpirvDirectly,    // bool (will be deprecated)
-    SPIRVCoreGrammarJSON, // stringValue0: json path
-    IncompleteLibrary,    // bool, when set, will not issue an error when the linked program has
-                          // unresolved extern function symbols.
+	EmitSpirvViaGLSL,     // bool (will be deprecated)
+	EmitSpirvDirectly,    // bool (will be deprecated)
+	SPIRVCoreGrammarJSON, // stringValue0: json path
+	IncompleteLibrary,    // bool, when set, will not issue an error when the linked program has
+						  // unresolved extern function symbols.
 
-    // Downstream
+	// Downstream
 
-    CompilerPath,
-    DefaultDownstreamCompiler,
-    DownstreamArgs, // stringValue0: downstream compiler name. stringValue1: argument list, one
-                    // per line.
-    PassThrough,
+	CompilerPath,
+	DefaultDownstreamCompiler,
+	DownstreamArgs, // stringValue0: downstream compiler name. stringValue1: argument list, one
+					// per line.
+	PassThrough,
 
-    // Repro
+	// Repro
 
-    DumpRepro,
-    DumpReproOnError,
-    ExtractRepro,
-    LoadRepro,
-    LoadReproDirectory,
-    ReproFallbackDirectory,
+	DumpRepro,
+	DumpReproOnError,
+	ExtractRepro,
+	LoadRepro,
+	LoadReproDirectory,
+	ReproFallbackDirectory,
 
-    // Debugging
+	// Debugging
 
-    DumpAst,
-    DumpIntermediatePrefix,
-    DumpIntermediates, // bool
-    DumpIr,            // bool
-    DumpIrIds,
-    PreprocessorOutput,
-    OutputIncludes,
-    ReproFileSystem,
-    REMOVED_SerialIR, // deprecated and removed
-    SkipCodeGen,      // bool
-    ValidateIr,       // bool
-    VerbosePaths,
-    VerifyDebugSerialIr,
-    NoCodeGen, // Not used.
+	DumpAst,
+	DumpIntermediatePrefix,
+	DumpIntermediates, // bool
+	DumpIr,            // bool
+	DumpIrIds,
+	PreprocessorOutput,
+	OutputIncludes,
+	ReproFileSystem,
+	REMOVED_SerialIR, // deprecated and removed
+	SkipCodeGen,      // bool
+	ValidateIr,       // bool
+	VerbosePaths,
+	VerifyDebugSerialIr,
+	NoCodeGen, // Not used.
 
-    // Experimental
+	// Experimental
 
-    FileSystem,
-    Heterogeneous,
-    NoMangle,
-    NoHLSLBinding,
-    NoHLSLPackConstantBufferElements,
-    ValidateUniformity,
-    AllowGLSL,
-    EnableExperimentalPasses,
-    BindlessSpaceIndex, // int
+	FileSystem,
+	Heterogeneous,
+	NoMangle,
+	NoHLSLBinding,
+	NoHLSLPackConstantBufferElements,
+	ValidateUniformity,
+	AllowGLSL,
+	EnableExperimentalPasses,
+	BindlessSpaceIndex, // int
 
-    // Internal
+	// Internal
 
-    ArchiveType,
-    CompileCoreModule,
-    Doc,
+	ArchiveType,
+	CompileCoreModule,
+	Doc,
 
-    IrCompression, //< deprecated
+	IrCompression, //< deprecated
 
-    LoadCoreModule,
-    ReferenceModule,
-    SaveCoreModule,
-    SaveCoreModuleBinSource,
-    TrackLiveness,
-    LoopInversion, // bool, enable loop inversion optimization
+	LoadCoreModule,
+	ReferenceModule,
+	SaveCoreModule,
+	SaveCoreModuleBinSource,
+	TrackLiveness,
+	LoopInversion, // bool, enable loop inversion optimization
 
-    ParameterBlocksUseRegisterSpaces, // Deprecated
-    LanguageVersion,                  // intValue0: SlangLanguageVersion
-    TypeConformance, // stringValue0: additional type conformance to link, in the format of
-                     // "<TypeName>:<IInterfaceName>[=<sequentialId>]", for example
-                     // "Impl:IFoo=3" or "Impl:IFoo".
-    EnableExperimentalDynamicDispatch, // bool, experimental
-    EmitReflectionJSON,                // bool
+	ParameterBlocksUseRegisterSpaces, // Deprecated
+	LanguageVersion,                  // intValue0: SlangLanguageVersion
+	TypeConformance, // stringValue0: additional type conformance to link, in the format of
+					 // "<TypeName>:<IInterfaceName>[=<sequentialId>]", for example
+					 // "Impl:IFoo=3" or "Impl:IFoo".
+	EnableExperimentalDynamicDispatch, // bool, experimental
+	EmitReflectionJSON,                // bool
 
-    CountOfParsableOptions,
+	CountOfParsableOptions,
 
-    // Used in parsed options only.
-    DebugInformationFormat,  // intValue0: DebugInfoFormat
-    VulkanBindShiftAll,      // intValue0: kind; intValue1: shift
-    GenerateWholeProgram,    // bool
-    UseUpToDateBinaryModule, // bool, when set, will only load
-                             // precompiled modules if it is up-to-date with its source.
-    EmbedDownstreamIR,       // bool
-    ForceDXLayout,           // bool
+	// Used in parsed options only.
+	DebugInformationFormat,  // intValue0: DebugInfoFormat
+	VulkanBindShiftAll,      // intValue0: kind; intValue1: shift
+	GenerateWholeProgram,    // bool
+	UseUpToDateBinaryModule, // bool, when set, will only load
+							 // precompiled modules if it is up-to-date with its source.
+	EmbedDownstreamIR,       // bool
+	ForceDXLayout,           // bool
 
-    // Add this new option to the end of the list to avoid breaking ABI as much as possible.
-    // Setting of EmitSpirvDirectly or EmitSpirvViaGLSL will turn into this option internally.
-    EmitSpirvMethod, // enum SlangEmitSpirvMethod
+	// Add this new option to the end of the list to avoid breaking ABI as much as possible.
+	// Setting of EmitSpirvDirectly or EmitSpirvViaGLSL will turn into this option internally.
+	EmitSpirvMethod, // enum SlangEmitSpirvMethod
 
-    SaveGLSLModuleBinSource,
+	SaveGLSLModuleBinSource,
 
-    SkipDownstreamLinking, // bool, experimental
-    DumpModule,
+	SkipDownstreamLinking, // bool, experimental
+	DumpModule,
 
-    GetModuleInfo,              // Print serialized module version and name
-    GetSupportedModuleVersions, // Print the min and max module versions this compiler supports
+	GetModuleInfo,              // Print serialized module version and name
+	GetSupportedModuleVersions, // Print the min and max module versions this compiler supports
 
-    EmitSeparateDebug, // bool
+	EmitSeparateDebug, // bool
 
-    // Floating point denormal handling modes
-    DenormalModeFp16,
-    DenormalModeFp32,
-    DenormalModeFp64,
+	// Floating point denormal handling modes
+	DenormalModeFp16,
+	DenormalModeFp32,
+	DenormalModeFp64,
 
-    // Bitfield options
-    UseMSVCStyleBitfieldPacking, // bool
+	// Bitfield options
+	UseMSVCStyleBitfieldPacking, // bool
 
-    ForceCLayout, // bool
+	ForceCLayout, // bool
 }
 
 CompilerOptionValueKind :: enum i32 {
@@ -563,7 +566,7 @@ IFileSystemExt_VTable :: struct {
 	calcCombinedPath     : proc "system"(this: ^IFileSystemExt, fromPath, path: cstring, pathOut: ^^IBlob) -> Result,
 	getPathType          : proc "system"(this: ^IFileSystemExt, path: cstring, pathTypeOut: ^PathType) -> Result,
 	getPath              : proc "system"(this: ^IFileSystemExt, path: cstring, outPath: ^^IBlob) -> Result,
-    clearCache           : proc "system"(this: ^IFileSystemExt),
+	clearCache           : proc "system"(this: ^IFileSystemExt),
 	enumeratePathContents: proc "system"(this: ^IFileSystemExt, path: cstring, callback: FileSystemContentsCallback, userData: rawptr) -> Result,
 	getOSPathKind        : proc "system"(this: ^IFileSystemExt) -> OSPathKind,
 }
@@ -665,8 +668,8 @@ IEntryPoint :: struct #raw_union {
 ITypeConformance :: struct #raw_union {
 	#subtype icomponenttype: IComponentType,
 	using vtable: ^struct {
-        using icomponenttype_vtable: IComponentType_VTable,
-    }
+		using icomponenttype_vtable: IComponentType_VTable,
+	},
 }
 
 IComponentType2 :: struct #raw_union {
@@ -1116,9 +1119,9 @@ IGlobalSession :: struct #raw_union {
 		parseCommandLineArguments         : proc "system"(this: ^IGlobalSession, argc: i32, argv: [^]cstring, outSessionDesc: ^SessionDesc, outAuxAllocation: ^^IUnknown) -> Result,
 		getSessionDescDigest              : proc "system"(this: ^IGlobalSession, sessionDesc: ^SessionDesc, outBlob: ^^IBlob) -> Result,
 		compileBuiltinModule:               proc "system"(this: ^IGlobalSession, module: BuiltinModuleName, flags: CompileCoreModuleFlags) -> Result, 
-        loadBuiltinModule:                  proc "system"(this: ^IGlobalSession, module: BuiltinModuleName, moduleData: rawptr, sizeInBytes: uint) -> Result, 
-        saveBuiltinModule:                  proc "system"(this: ^IGlobalSession, module: BuiltinModuleName, outBlob: ^^IBlob) -> Result,
-    },
+		loadBuiltinModule:                  proc "system"(this: ^IGlobalSession, module: BuiltinModuleName, moduleData: rawptr, sizeInBytes: uint) -> Result, 
+		saveBuiltinModule:                  proc "system"(this: ^IGlobalSession, module: BuiltinModuleName, outBlob: ^^IBlob) -> Result,
+	},
 }
 
 @(link_prefix="slang_")

--- a/slang/slang.odin
+++ b/slang/slang.odin
@@ -621,19 +621,6 @@ DiagnosticCallback :: #type proc "c"(message: cstring, userData: rawptr)
 
 
 
-
-ProgramLayout :: struct {
-    _pad0: [1]u8,
-}
-
-FunctionReflection :: struct {
-    _pad0: [1]u8,
-}
-
-DeclReflection :: struct {
-    _pad0: [1]u8,
-}
-
 IComponentType :: struct #raw_union {
 	#subtype iunknown: IUnknown,
 	using vtable: ^IComponentType_VTable,
@@ -796,235 +783,16 @@ SessionDesc :: struct {
 	skipSPIRVValidation     : bool,
 }
 
-
-
-ReflectionGenericArgType :: enum i32 {
-	TYPE,
-	INT,
-	BOOL,
-}
-
-TypeKind :: enum u32 {
-	NONE,
-	STRUCT,
-	ARRAY,
-	MATRIX,
-	VECTOR,
-	SCALAR,
-	CONSTANT_BUFFER,
-	RESOURCE,
-	SAMPLER_STATE,
-	TEXTURE_BUFFER,
-	SHADER_STORAGE_BUFFER,
-	PARAMETER_BLOCK,
-	GENERIC_TYPE_PARAMETER,
-	INTERFACE,
-	OUTPUT_STREAM,
-	MESH_OUTPUT,
-	SPECIALIZED,
-	FEEDBACK,
-	POINTER,
-	DYNAMIC_RESOURCE,
-}
-
-ScalarType :: enum u32 {
-	NONE,
-	VOID,
-	BOOL,
-	INT32,
-	UINT32,
-	INT64,
-	UINT64,
-	FLOAT16,
-	FLOAT32,
-	FLOAT64,
-	INT8,
-	UINT8,
-	INT16,
-	UINT16,
-	INTPTR,
-	UINTPTR,
-}
-
-DeclKind :: enum u32 {
-	UNSUPPORTED_FOR_REFLECTION,
-	STRUCT,
-	FUNC,
-	MODULE,
-	GENERIC,
-	VARIABLE,
-	NAMESPACE,
-}
-
-SlangResourceShape :: enum u32 {
-	BASE_SHAPE_MASK              = 0x0F,
-	NONE                         = 0x00,
-	TEXTURE_1D                   = 0x01,
-	TEXTURE_2D                   = 0x02,
-	TEXTURE_3D                   = 0x03,
-	TEXTURE_CUBE                 = 0x04,
-	TEXTURE_BUFFER               = 0x05,
-	STRUCTURED_BUFFER            = 0x06,
-	BYTE_ADDRESS_BUFFER          = 0x07,
-	RESOURCE_UNKNOWN             = 0x08,
-	ACCELERATION_STRUCTURE       = 0x09,
-	TEXTURE_SUBPASS              = 0x0A,
-	RESOURCE_EXT_SHAPE_MASK      = 0x1F0,
-	TEXTURE_FEEDBACK_FLAG        = 0x10,
-	TEXTURE_SHADOW_FLAG          = 0x20,
-	TEXTURE_ARRAY_FLAG           = 0x40,
-	TEXTURE_MULTISAMPLE_FLAG     = 0x80,
-	TEXTURE_COMBINED_FLAG        = 0x100,
-	TEXTURE_1D_ARRAY             = TEXTURE_1D | TEXTURE_ARRAY_FLAG,
-	TEXTURE_2D_ARRAY             = TEXTURE_2D | TEXTURE_ARRAY_FLAG,
-	TEXTURE_CUBE_ARRAY           = TEXTURE_CUBE | TEXTURE_ARRAY_FLAG,
-	TEXTURE_2D_MULTISAMPLE       = TEXTURE_2D | TEXTURE_MULTISAMPLE_FLAG,
-	TEXTURE_2D_MULTISAMPLE_ARRAY = TEXTURE_2D | TEXTURE_MULTISAMPLE_FLAG | TEXTURE_ARRAY_FLAG,
-	TEXTURE_SUBPASS_MULTISAMPLE  = TEXTURE_SUBPASS | TEXTURE_MULTISAMPLE_FLAG,
-}
-
-ResourceAccess :: enum u32 {
-	NONE,
-	READ,
-	READ_WRITE,
-	RASTER_ORDERED,
-	APPEND,
-	CONSUME,
-	WRITE,
-	FEEDBACK,
-	UNKNOWN = 0x7FFFFFFF,
-}
-
-ParameterCategory :: enum u32 {
-	NONE,
-	MIXED,
-	CONSTANT_BUFFER,
-	SHADER_RESOURCE,
-	UNORDERED_ACCESS,
-	VARYING_INPUT,
-	VARYING_OUTPUT,
-	SAMPLER_STATE,
-	UNIFORM,
-	DESCRIPTOR_TABLE_SLOT,
-	SPECIALIZATION_CONSTANT,
-	PUSH_CONSTANT_BUFFER,
-	// HLSL register `space`, Vulkan GLSL `set`
-	REGISTER_SPACE,
-	// TODO: Ellie, Both APIs treat mesh outputs as more or less varying output,
-	// Does it deserve to be represented here??
-	// A parameter whose type is to be specialized by a global generic type argument
-	GENERIC,
-	RAY_PAYLOAD,
-	HIT_ATTRIBUTES,
-	CALLABLE_PAYLOAD,
-	SHADER_RECORD,
-	// An existential type parameter represents a "hole" that
-	// needs to be filled with a concrete type to enable
-	// generation of specialized code.
-	//
-	// Consider this example:
-	//
-	//      struct MyParams
-	//      {
-	//          IMaterial material;
-	//          ILight lights[3];
-	//      };
-	//
-	// This `MyParams` type introduces two existential type parameters:
-	// one for `material` and one for `lights`. Even though `lights`
-	// is an array, it only introduces one type parameter, because
-	// we need to hae a *single* concrete type for all the array
-	// elements to be able to generate specialized code.
-	//
-	EXISTENTIAL_TYPE_PARAM,
-	// An existential object parameter represents a value
-	// that needs to be passed in to provide data for some
-	// interface-type shader paameter.
-	//
-	// Consider this example:
-	//
-	//      struct MyParams
-	//      {
-	//          IMaterial material;
-	//          ILight lights[3];
-	//      };
-	//
-	// This `MyParams` type introduces four existential object parameters:
-	// one for `material` and three for `lights` (one for each array
-	// element). This is consistent with the number of interface-type
-	// "objects" that are being passed through to the shader.
-	//
-	EXISTENTIAL_OBJECT_PARAM,
-	// The register space offset for the sub-elements that occupies register spaces.
-	SUB_ELEMENT_REGISTER_SPACE,
-	// The input_attachment_index subpass occupancy tracker
-	SUBPASS,
-	// Metal tier-1 argument buffer element [[id]].
-	METAL_ARGUMENT_BUFFER_ELEMENT,
-	// Metal [[attribute]] inputs.
-	METAL_ATTRIBUTE,
-	// Metal [[payload]] inputs
-	METAL_PAYLOAD,
-}
-
-BindingType :: enum u32 {
-	UNKNOWN = 0,
-	SAMPLER,
-	TEXTURE,
-	CONSTANT_BUFFER,
-	PARAMETER_BLOCK,
-	TYPED_BUFFER,
-	RAW_BUFFER,
-	COMBINED_TEXTURE_SAMPLER,
-	INPUT_RENDER_TARGET,
-	INLINE_UNIFORM_DATA,
-	RAY_TRACING_ACCELERATION_STRUCTURE,
-	VARYING_INPUT,
-	VARYING_OUTPUT,
-	EXISTENTIAL_VALUE,
-	PUSH_CONSTANT,
-	MUTABLE_FLAG = 0x100,
-
-	// TODO(Dragos): fix typo in main repo SLANG_BINDING_TYPE_MUTABLE_TETURE
-	MUTABLE_TEXTURE = TEXTURE | MUTABLE_FLAG,
-   	MUTABLE_TYPED_BUFFER = TYPED_BUFFER | MUTABLE_FLAG,
-	MUTABLE_RAW_BUFFER = RAW_BUFFER | MUTABLE_FLAG,
-
-	BASE_MASK = 0x00FF,
-	EXT_MASK = 0xFF00,
-}
-
-SlangModifierID :: enum u32 {
-	SHARED,
-	NO_DIFF,
-	STATIC,
-	CONST,
-	EXPORT,
-	EXTERN,
-	DIFFERENTIABLE,
-	MUTATING,
-	IN,
-	OUT,
-	INOUT,
-}
-
-ImageFormat :: u32 {
+ImageFormat :: enum u32 {
 	// TODO(Dragos): see slang-image-format-defs.h
 }
 
 UNBOUNDED_SIZE :: ~uint(0)
-
-TypeReflection :: struct {
-
-}
+UNKNOWN_SIZE   :: UNBOUNDED_SIZE - 1
 
 LayoutRules :: enum u32 {
 	DEFAULT,
 	METAL_ARGUMENT_BUFFER_TIER_2,
-}
-
-TypeLayoutReflection :: struct {
-
 }
 
 ContainerType :: enum i32 {
@@ -1068,7 +836,7 @@ IMetadata :: struct #raw_union {
 	#subtype icastable: ICastable,
 	using vtable: ^struct {
 		using icastable_vtable: ICastable_VTable,
-		isParameterLocationUsed: proc "system"(this: ^IMetadata, category: ParameterCategory, spaceIndex, registerIndex: UInt, outUsed: ^bool) -> Result,
+		isParameterLocationUsed: proc "system"(this: ^IMetadata, category: SlangParameterCategory, spaceIndex, registerIndex: UInt, outUsed: ^bool) -> Result,
 		getDebugBuildIdentifier: proc "system"(this: ^IMetadata) -> cstring,
 	},
 }
@@ -1137,10 +905,3 @@ foreign libslang {
 	getLastInternalErrorMessage :: proc() -> cstring ---
 }
 
-// NOTE(Dragos): sp functions seem to want to become deprecated, but some still exist
-@(link_prefix="sp")
-@(default_calling_convention="c")
-foreign libslang {
-	ReflectionType_GetKind :: proc(type: ^TypeReflection) -> TypeKind ---
-	ReflectionType_GetFieldCount :: proc(type: ^TypeReflection) -> u32 ---
-}

--- a/slang/slang.odin
+++ b/slang/slang.odin
@@ -617,7 +617,7 @@ IProfiler :: struct #raw_union {
 	},
 }
 
-DiagnosticsCallback :: #type proc "c"(message: cstring, userData: rawptr)
+DiagnosticCallback :: #type proc "c"(message: cstring, userData: rawptr)
 
 
 
@@ -1051,7 +1051,7 @@ ISession :: struct #raw_union {
 		getTypeRTTIMangledName               : proc "system"(this: ^ISession, type: ^TypeReflection, outNameBlob: ^^IBlob) -> Result,
 		getTypeConformanceWitnessMangledName : proc "system"(this: ^ISession, type: ^TypeReflection, interfaceType: ^TypeReflection, outNameBlob: ^^IBlob) -> Result,
 		getTypeConformanceWitnessSequentialID: proc "system"(this: ^ISession, type: ^TypeReflection, interfaceType: ^TypeReflection, outId: ^u32) -> Result,
-		createCompilerRequest                : proc "system"(this: ^ISession, outCompileRequest: ^^ICompileRequest) -> Result,
+		createCompileRequest                 : proc "system"(this: ^ISession, outCompileRequest: ^^ICompileRequest) -> Result,
 		createTypeConformanceComponentType   : proc "system"(this: ^ISession, type: ^TypeReflection, interfaceType: ^TypeReflection, outConformance: ^^ITypeConformance, conformanceIdOverride: Int, outDiagnostics: ^^IBlob) -> Result,
 		loadModuleFromIRBlob                 : proc "system"(this: ^ISession, moduleName: cstring, path: cstring, source: ^IBlob, outDiagnostics: ^^IBlob) -> ^IModule,
 		getLoadedModuleCount                 : proc "system"(this: ^ISession) -> Int,
@@ -1102,7 +1102,7 @@ IGlobalSession :: struct #raw_union {
 		getDefaultDownstreamCompiler      : proc "system"(this: ^IGlobalSession, sourceLanguage: SourceLanguage) -> PassThrough,
 		setLanguagePrelude                : proc "system"(this: ^IGlobalSession, sourceLanguage: SourceLanguage, preludeText: cstring),
 		getLanguagePrelude                : proc "system"(this: ^IGlobalSession, sourceLanguage: SourceLanguage, outPrelude: ^^IBlob),
-		createCompilerRequest             : proc "system"(this: ^IGlobalSession, outCompilerRequest: ^^ICompileRequest) -> Result, /* [deprecated] */
+		createCompileRequest              : proc "system"(this: ^IGlobalSession, outCompilerRequest: ^^ICompileRequest) -> Result, /* [deprecated] */
 		addBuiltins                       : proc "system"(this: ^IGlobalSession, sourcePath: cstring, sourceString: cstring),
 		setSharedLibraryLoader            : proc "system"(this: ^IGlobalSession, loader: ^ISharedLibraryLoader),
 		getSharedLibraryLoader            : proc "system"(this: ^IGlobalSession) -> ^ISharedLibraryLoader,


### PR DESCRIPTION
Hey, here's the draft of the additions:

It's separated into commits so if there are parts you're not interested in adding
you can just cherrypick. Alternatively I can split this into multiple PRs if needed.

1. Minor fixes to whitespace, and a few proc names

2. Added ICompileRequest though it probably shouldn't be used in fresh projects, I needed it for porting an older one.

3. Added bindings for Reflection and moved reflection related enums into separate file
- Problematic part here is that slang namespacing is kind of a clusterfuck
so for example if we go by the usual convention of removing the "Slang" prefix
from type names we end up with collision because both ParameterCategory and SlangParameterCategory
exist.. So I ended up re-adding the "Slang" to several enums.
- There were also several structs that had up to like 5 different aliases accross the 2 headers but 
I think I managed to correctly alias or cull all those.. (e.g. ProgramLayout)
- Most of the newer api seems to use the Pascal case enums for ID and ParameterCategory
some of the enums are also namespaced inside structs so that required some naming weirdness.
- Last, this might be a bit questionable but I ended up using LayoutUnit instead of ParameterCategory
everywhere in the bindings, it is just an alias, but it seems to be the preferred terminology
according to Tess here: https://www.youtube.com/watch?v=OxOZ81N3NKw
and I agree it's an infinitely better name.


4. Added "helper methods". 
In the current slang API while most of reflection sits
in the deprecated header, the go to way to use it is through these methods
that are just a thin wrapper over the deprecated procs.
They currently can't be bound directly since they are C++ member functions
so I just ported them over. See: reflection_helper_methods.odin

5. Reflection wrapper vtables.
I'm not sure how I feel about this as a solution yet so I placed it in a separate package.
But it is an attempt at futureproofing user code by manually creating vtables for now.
See: reflection_wrapper_public.odin

6. Added the reflection api example using both the raw and wrapped methods.

note: ReflectionDecl_findModifier will need an update to the included slang binaries it seems. I'm getting
a linker error if I try to compile with the versions currently in the repo.

